### PR TITLE
fix: Add repository-specific conditions to GitHub workflows

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   dependency-submission:
     runs-on: ubuntu-latest
+    if: github.repository == 'docling-project/docling-java'
     steps:
     - name: Checkout sources
       uses: actions/checkout@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     name: Build Docs
+    if: github.repository == 'docling-project/docling-java'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -19,7 +19,7 @@ jobs:
   get-pr-info:
     runs-on: ubuntu-latest
     name: Get PR info
-    if: github.event.workflow_run.event == 'pull_request'
+    if: (github.event.workflow_run.event == 'pull_request') && (github.repository == 'docling-project/docling-java')
     outputs:
       pr_number: ${{ steps.pr.outputs.number }}
     steps:
@@ -38,7 +38,7 @@ jobs:
   build-reports:
     runs-on: ubuntu-latest
     name: Build test report
-    if: github.event.workflow_run.event == 'pull_request'
+    if: (github.event.workflow_run.event == 'pull_request') && (github.repository == 'docling-project/docling-java')
     needs: get-pr-info
     steps:
 #      - name: Download current GitHub Pages

--- a/.github/workflows/version-tests.yml
+++ b/.github/workflows/version-tests.yml
@@ -49,6 +49,7 @@ defaults:
 jobs:
   versions-tests:
     runs-on: ubuntu-latest
+    if: github.repository == 'docling-project/docling-java'
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
- Ensured workflows run only for 'docling-project/docling-java' repository.
- Updated `dependency-submission`, `version-tests`, `test-reporting`, and `docs` workflows.