### PR TITLE
feat: dynamically set project version from project.yml

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
   current-version: 0.0.1
-  next-version: 999-SNAPSHOT
+  next-version: 0.1.0

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,6 +4,11 @@ plugins {
 
 repositories {
   gradlePluginPortal()
+  mavenCentral()
+}
+
+dependencies {
+  implementation("org.yaml:snakeyaml:2.4")
 }
 
 // Read root gradle.properties

--- a/buildSrc/src/main/kotlin/docling-shared.gradle.kts
+++ b/buildSrc/src/main/kotlin/docling-shared.gradle.kts
@@ -1,2 +1,35 @@
 group = "ai.docling"
-version = property("version").toString()
+
+// Reads .github/project.yml and sets the project version from key release.current-version.
+// It also exposes the value as a Gradle property named "version" (extra) so other plugins/scripts
+// that call property("version") see the correct value.
+
+fun readReleaseCurrentVersion(): String? {
+  val yamlFile = rootProject.layout.projectDirectory.dir(".github").file("project.yml")
+
+  if (!yamlFile.asFile.exists()) {
+    throw GradleException("Missing .github/project.yml file in root project directory. Unable to determine project version.")
+  }
+
+  val yaml = org.yaml.snakeyaml.Yaml()
+
+  yamlFile.asFile.inputStream().use { input ->
+    val data = yaml.load<Any>(input) ?: return null
+
+    if (data is Map<*, *>) {
+      val release = data["release"]
+
+      if (release is Map<*, *>) {
+        val current = release["current-version"]
+
+        if (current is String) {
+          return current.trim()
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+version = readReleaseCurrentVersion() ?: property("version").toString()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,1 @@
-# Gradle properties
-
 java.version=17
-version=0.0.1-SNAPSHOT


### PR DESCRIPTION
- Implemented logic to read the current version from `.github/project.yml`.
- Replaced hardcoded version in `gradle.properties` with dynamic loading logic.
- Added SnakeYAML dependency to parse YAML files.
- Updated `buildSrc` configuration to support YAML parsing and version retrieval.