### PR TITLE
docs: update documentation for testing, client, and API modules

### DIFF
--- a/docs/src/doc/docs/docling-serve/serve-api.md
+++ b/docs/src/doc/docs/docling-serve/serve-api.md
@@ -1,5 +1,185 @@
 # Docling Serve API
 
+The `docling-serve-api` module defines the core, framework-agnostic Java API used to communicate
+with a [Docling Serve](https://github.com/docling-project/docling-serve) backend. It provides the request/response model and the main `DoclingServeApi`
+interface. You can use any implementation of this interface to talk to a running
+[Docling Serve](https://github.com/docling-project/docling-serve) instance.
+
+The base Java version is 17. This module has no other required dependencies, although it is compatible with both Jackson [2.x](https://github.com/FasterXML/jackson) and [3.x](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md).
+
+If you need a ready-to-use HTTP implementation, see the reference client:
+- Docling Serve Client: [`docling-serve-client`](serve-client.md)
+
+## When to use this module
+
+- You want a stable, typed Java model for Docling Serve requests/responses without committing to a
+  specific HTTP stack.
+- You plan to create your own client implementation (e.g., different HTTP lib, reactive runtime) but
+  still rely on the shared API model.
+- You want to write code that is portable across different client implementations.
+
+## Installation
+
+Add the API dependency to your project.
+
+=== "Gradle"
+
+    ``` kotlin
+    dependencies {
+      implementation("{{ gradle.project_groupId }}:{{ gradle.serve_api_artifactId }}:{{ gradle.project_version }}")
+    }
+    ```
+
+=== "Maven"
+
+    ``` xml
+    <dependency>
+      <groupId>{{ gradle.project_groupId }}</groupId>
+      <artifactId>{{ gradle.serve_api_artifactId }}</artifactId>
+      <version>{{ gradle.project_version }}</version>
+    </dependency>
+    ```
+
+Note: The API module does not perform network I/O by itself. To call a live service, combine it with
+an implementation such as [`docling-serve-client`](serve-client.md).
+
+## Quick start
+
+Below is a minimal example using the reference client to create an implementation of `DoclingServeApi`,
+build a conversion request, and retrieve Markdown output. The request/response types all come from
+`docling-serve-api`.
+
+```java
+import java.net.URI;
+import ai.docling.api.serve.DoclingServeApi;
+import ai.docling.api.serve.convert.request.ConvertDocumentRequest;
+import ai.docling.api.serve.convert.request.options.ConvertDocumentOptions;
+import ai.docling.api.serve.convert.request.options.OutputFormat;
+import ai.docling.api.serve.convert.request.source.HttpSource;
+import ai.docling.api.serve.convert.request.target.InBodyTarget;
+import ai.docling.api.serve.convert.response.ConvertDocumentResponse;
+import ai.docling.client.serve.DoclingServeClientBuilderFactory; // from docling-serve-client
+
+DoclingServeApi api = DoclingServeClientBuilderFactory
+    .newBuilder()
+    .baseUrl("http://localhost:8000") // your Docling Serve URL
+    .build();
+
+ConvertDocumentRequest request = ConvertDocumentRequest.builder()
+    .source(HttpSource.builder().url(URI.create("https://arxiv.org/pdf/2408.09869"))
+        .build())
+    .options(ConvertDocumentOptions.builder()
+        .toFormat(OutputFormat.MARKDOWN) // request Markdown output
+        .includeImages(true)
+        .build())
+    .target(InBodyTarget.builder().build()) // get results in the HTTP response body
+    .build();
+
+ConvertDocumentResponse response = api.convertSource(request);
+System.out.println(response.getDocument().getMarkdownContent());
+```
+
+## Core concepts
+
+### The `DoclingServeApi` interface
+
+Defined in `ai.docling.api.serve.DoclingServeApi`, this interface exposes two primary operations:
+
+- `health()` → returns a `HealthCheckResponse` with service status.
+- `convertSource(request)` → submits one or more sources plus options and an optional target,
+  returning `ConvertDocumentResponse`.
+
+Any HTTP or non-HTTP implementation can implement this interface. The reference implementation is
+provided by the `docling-serve-client` module.
+
+### Requests: `ConvertDocumentRequest`
+
+Create a request via the builder:
+
+```java
+ConvertDocumentRequest request = ConvertDocumentRequest.builder()
+    .source(/* one of the supported sources */)
+    .options(/* conversion options */)
+    .target(/* optional delivery target */)
+    .build();
+```
+
+Supported sources (`ai.docling.api.serve.convert.request.source`):
+- `HttpSource` — fetch content from a URL (optional custom headers)
+- `FileSource` — embed content as Base64 with a filename
+
+Targets (`ai.docling.api.serve.convert.request.target`):
+- `InBodyTarget` — receive results directly in the API response body (default use case)
+- `PutTarget` — the service uploads converted content via HTTP PUT to a specified URI
+- `ZipTarget` — receive a zipped result
+
+Options (`ai.docling.api.serve.convert.request.options.ConvertDocumentOptions`) let you control:
+- Input/output formats (e.g., `fromFormats`, `toFormats`)
+- OCR (e.g., `doOcr`, `forceOcr`, `ocrEngine`, `ocrLang`)
+- PDF processing (e.g., `pdfBackend`)
+- Tables (e.g., `tableMode`, `tableCellMatching`)
+- Pipelines and page ranges (e.g., `pipeline`, `pageRange`)
+- Timeouts and error behavior (e.g., `documentTimeout`, `abortOnError`)
+- Enrichments (code/formula/picture), image handling, scaling, page break placeholder
+- VLM pipeline hints
+
+Explore the `options` package for the full list of knobs you can turn.
+
+### Responses: `ConvertDocumentResponse` and `DocumentResponse`
+
+- `ConvertDocumentResponse` contains the converted `document` (if any), `errors`, processing `status`,
+  total `processing_time`, and detailed `timings` map.
+- `DocumentResponse` holds the actual content fields you requested, such as `md_content` (Markdown),
+  `html_content`, `text_content`, and a `json_content` map. It also includes the `filename` and
+  `doctags_content` when relevant.
+
+## Health checks
+
+You can ping the service to check readiness and basic status:
+
+```java
+import ai.docling.api.serve.health.HealthCheckResponse;
+
+HealthCheckResponse health = api.health();
+System.out.println("Service status: " + health.getStatus());
+```
+
+## Error handling
+
+Conversion may succeed partially (e.g., some pages) while returning warnings or errors. Always inspect
+`ConvertDocumentResponse#getErrors()` and consider `status`:
+
+```java
+ConvertDocumentResponse response = api.convertSource(request);
+
+if (response.getErrors() != null && !response.getErrors().isEmpty()) {
+  response.getErrors().forEach(err ->
+      System.err.println("Component: " + err.getComponentType() + 
+          ", Module: " + err.getModuleName() + 
+          ", Message: " + err.getErrorMessage()));
+}
+
+if (response.getDocument() != null && response.getDocument().getMarkdownContent() != null) {
+  // Use the output
+}
+```
+
+The exact transport-level exceptions (e.g., timeouts, connectivity) depend on the client implementation
+you use. The reference client throws standard Java exceptions for HTTP and I/O failures.
+
+## Logging and builders
+
+`DoclingServeApi` exposes a `toBuilder()` method so implementations can be duplicated and tweaked. Most
+client builders, including the reference client, also expose `logRequests()` and `logResponses()` for
+simple diagnostics:
+
+```java
+DoclingServeApi newApi = api.toBuilder()
+    .logRequests()
+    .logResponses()
+    .build();
+```
+
 ## Version compatibility
 
 The API is tested against all published versions of Docling Serve each week. Below are the latest run results:

--- a/docs/src/doc/docs/docling-serve/serve-client.md
+++ b/docs/src/doc/docs/docling-serve/serve-client.md
@@ -1,8 +1,211 @@
 # Docling Serve Client
 
+The `docling-serve-client` module is the reference HTTP client for talking to a
+[Docling Serve](https://github.com/docling-project/docling-serve) backend.
+
+It implements the framework‑agnostic `DoclingServeApi` interface from
+[`docling-serve-api`](serve-api.md) using Java's built‑in `HttpClient` for transport and
+Jackson for JSON (auto‑detecting Jackson 2 or 3 at runtime).
+
+If you only need the request/response model (without HTTP), use the API module:
+- [`docling-serve-api`](serve-api.md)
+
+## When to use this module
+
+- You want a ready‑to‑use HTTP client for Docling Serve with minimal setup.
+- You prefer a small dependency footprint (Java `HttpClient` + Jackson).
+- You need a simple builder to tweak base URL, HTTP timeouts, and request/response logging.
+
+## Installation
+
+Add the client dependency to your project.
+
+=== "Gradle"
+
+    ``` kotlin
+    dependencies {
+      implementation("{{ gradle.project_groupId }}:{{ gradle.serve_client_artifactId }}:{{ gradle.project_version }}")
+    }
+    ```
+
+=== "Maven"
+
+    ``` xml
+    <dependency>
+      <groupId>{{ gradle.project_groupId }}</groupId>
+      <artifactId>{{ gradle.serve_client_artifactId }}</artifactId>
+      <version>{{ gradle.project_version }}</version>
+    </dependency>
+    ```
+
+This artifact brings in the API types transitively, so you can use `DoclingServeApi`,
+`ConvertDocumentRequest`, etc., directly.
+
+???+ warning "Jackson Implementation Required"
+
+    Make sure you also include either a Jackson 2 or Jackson 3 dependency.
+
+## Quick start
+
+Create a client with `DoclingServeClientBuilderFactory`, build a request, and call `convertSource()`:
+
+```java
+import java.net.URI;
+import ai.docling.api.serve.DoclingServeApi;
+import ai.docling.api.serve.convert.request.ConvertDocumentRequest;
+import ai.docling.api.serve.convert.request.options.ConvertDocumentOptions;
+import ai.docling.api.serve.convert.request.options.OutputFormat;
+import ai.docling.api.serve.convert.request.source.HttpSource;
+import ai.docling.api.serve.convert.request.target.InBodyTarget;
+import ai.docling.api.serve.convert.response.ConvertDocumentResponse;
+import ai.docling.client.serve.DoclingServeClientBuilderFactory;
+
+DoclingServeApi api = DoclingServeClientBuilderFactory
+    .newBuilder()
+    .baseUrl("http://localhost:8000") // your Docling Serve URL
+    .build();
+
+ConvertDocumentRequest request = ConvertDocumentRequest.builder()
+    .source(HttpSource.builder().url(URI.create("https://arxiv.org/pdf/2408.09869")).build())
+    .options(ConvertDocumentOptions.builder()
+        .toFormat(OutputFormat.MARKDOWN)
+        .includeImages(true)
+        .build())
+    .target(InBodyTarget.builder().build())
+    .build();
+
+ConvertDocumentResponse response = api.convertSource(request);
+System.out.println(response.getDocument().getMarkdownContent());
+```
+
+## Core concepts and configuration
+
+### Builder factory and Jackson auto‑detection
+
+`DoclingServeClientBuilderFactory.newBuilder()` chooses an implementation based on what's on
+your classpath:
+
+- Jackson 3 present → `DoclingServeJackson3Client`
+- Else if Jackson 2 present → `DoclingServeJackson2Client`
+- Otherwise → `IllegalStateException`
+
+Advanced: You can customize the JSON mapper via `.toBuilder().jsonParser(...)` on the concrete
+client type if you need special Jackson modules or settings.
+
+### Base URL
+
+Set the Docling Serve base URL with either a `String` or `URI`:
+
+```java
+DoclingServeApi api = DoclingServeClientBuilderFactory.newBuilder()
+    .baseUrl("http://localhost:8000")
+    .build();
+```
+
+Note: When using plain `http://`, the client enforces HTTP/1.1 for compatibility with FastAPI,
+which avoids HTTP/2 downgrade mishaps in some environments.
+
+### HTTP client customization (timeouts, proxies, TLS)
+
+You can supply and tune a `java.net.http.HttpClient.Builder`:
+
+```java
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+DoclingServeApi api = DoclingServeClientBuilderFactory.newBuilder()
+    .baseUrl("https://serve.example.com")
+    .httpClientBuilder(HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(20))
+        // .proxy(ProxySelector.of(new InetSocketAddress("proxy", 8080)))
+        // .sslContext(customSslContext)
+    )
+    .build();
+```
+
+### Request/response logging
+
+Enable lightweight logging for diagnostics:
+
+```java
+DoclingServeApi noisy = DoclingServeClientBuilderFactory.newBuilder()
+    .baseUrl("http://localhost:8000")
+    .logRequests()
+    .logResponses()
+    .build();
+```
+
+### Health checks
+
+```java
+import ai.docling.api.serve.health.HealthCheckResponse;
+
+HealthCheckResponse health = api.health();
+System.out.println("Service status: " + health.getStatus());
+```
+
+## Working with sources and targets
+
+All request/response types come from [`docling-serve-api`](serve-api.md). Common patterns:
+
+- HTTP source
+
+  ```java
+  import ai.docling.api.serve.convert.request.source.HttpSource;
+  var httpSource = HttpSource.builder()
+      .url(URI.create("https://example.com/file.pdf"))
+      // .header("Authorization", "Bearer ...")
+      .build();
+  ```
+
+- File upload (Base64)
+
+  ```java
+  import java.util.Base64;
+  import ai.docling.api.serve.convert.request.source.FileSource;
+  byte[] bytes = /* read file */
+  var fileSource = FileSource.builder()
+      .filename("report.pdf")
+      .base64String(Base64.getEncoder().encodeToString(bytes))
+      .build();
+  ```
+
+- Deliver results in the response body (default)
+
+  ```java
+  import ai.docling.api.serve.convert.request.target.InBodyTarget;
+  var target = InBodyTarget.builder().build();
+  ```
+
+- Upload results to your storage via HTTP PUT
+
+  ```java
+  import ai.docling.api.serve.convert.request.target.PutTarget;
+  var put = PutTarget.builder()
+      .uri(URI.create("https://storage.example.com/out/report.md"))
+      // .header("Authorization", "Bearer ...")
+      .build();
+  ```
+
+## Error handling tips
+
+Transport errors (DNS, TLS, connection reset, timeouts) are thrown as standard Java exceptions
+from `HttpClient`. Conversion may also return structured errors in the response body — inspect
+`ConvertDocumentResponse#getErrors()` even when content is present:
+
+```java
+var result = api.convertSource(request);
+if (result.getErrors() != null && !result.getErrors().isEmpty()) {
+  result.getErrors().forEach(err ->
+      System.err.println("Component=" + err.getComponentType()
+          + ", Module=" + err.getModuleName()
+          + ", Message=" + err.getErrorMessage()));
+}
+```
+
 ## Version compatibility
 
-The API is tested against all published versions of Docling Serve each week. Below are the latest run results:
+The client is tested against all published versions of Docling Serve each week. Below are the latest run results:
 
 {%
     include-markdown "includes/docling-serve/serve-compatibility.md"

--- a/docs/src/doc/docs/testcontainers.md
+++ b/docs/src/doc/docs/testcontainers.md
@@ -1,1 +1,166 @@
 # Testcontainers
+
+The `docling-testcontainers` module provides a ready-to-use [Testcontainers](https://testcontainers.com/) integration for running a [Docling Serve](https://github.com/docling-project/docling-serve) instance in your tests. It wraps the official container image and exposes a simple Java API so you can spin up Docling as part of your JUnit test lifecycle and exercise client code against a real server.
+
+If you need to talk to a running server from your application code, pair this module with the reference HTTP client:
+- [`docling-serve-client`](docling-serve/serve-client.md)
+
+## When to use this module
+
+- You want end-to-end tests that run against a real Docling Serve in Docker.
+- You need a portable, reliable way to boot Docling Serve on CI without managing it yourself.
+- You want a convenient Java API to tweak the container image, environment variables, startup timeout, and optional UI.
+
+## Installation
+
+Add the Testcontainers module to your test dependencies.
+
+=== "Gradle"
+
+    ``` kotlin
+    dependencies {
+        testImplementation("{{ gradle.project_groupId }}:{{ gradle.testcontainers_artifactId }}:{{ gradle.project_version }}")
+    }
+    ```
+
+=== "Maven"
+
+    ``` xml
+    <dependencies>
+      <dependency>
+        <groupId>{{ gradle.project_groupId }}</groupId>
+        <artifactId>{{ gradle.testcontainers_artifactId }}</artifactId>
+        <version>{{ gradle.project_version }}</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+    ```
+
+## Quick start
+
+Spin up Docling Serve with JUnit 5 and run a simple health check using the reference client.
+
+```java
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import ai.docling.api.serve.DoclingServeApi;
+import ai.docling.api.serve.health.HealthCheckResponse;
+import ai.docling.client.serve.DoclingServeClientBuilderFactory;
+import ai.docling.testcontainers.serve.DoclingServeContainer;
+import ai.docling.testcontainers.serve.config.DoclingServeContainerConfig;
+
+@Testcontainers
+class DoclingContainerSmokeTest {
+  @Container
+  private final DoclingServeContainer docling = new DoclingServeContainer(
+      DoclingServeContainerConfig.builder()
+          .image(DoclingServeContainerConfig.DOCLING_IMAGE)
+          .enableUi(true)
+          .build()
+  );
+
+  @Test
+  void health_is_ok() {
+    String base = "http://" + docling.getHost() + ":" + docling.getPort();
+
+    DoclingServeApi api = DoclingServeClientBuilderFactory
+        .newBuilder()
+        .baseUrl(base)
+        .build();
+
+    HealthCheckResponse health = api.health();
+    assertThat(health.getStatus()).isNotBlank();
+  }
+}
+```
+
+???+ note
+
+    - `@Container` manages container lifecycle for you. Use a `static` field to reuse the container across tests in the class.
+    - `getHost()` and `getPort()` are provided by Testcontainers/`GenericContainer`; `getPort()` maps the container’s internal port to a random free host port.
+
+## Using it with the reference client for conversions
+
+Once the container is up, you can call the Convert endpoint through `docling-serve-client`:
+
+```java
+import java.net.URI;
+import ai.docling.api.serve.convert.request.ConvertDocumentRequest;
+import ai.docling.api.serve.convert.request.options.ConvertDocumentOptions;
+import ai.docling.api.serve.convert.request.options.OutputFormat;
+import ai.docling.api.serve.convert.request.source.HttpSource;
+import ai.docling.api.serve.convert.request.target.InBodyTarget;
+import ai.docling.api.serve.convert.response.ConvertDocumentResponse;
+
+String baseUrl = "http://" + docling.getHost() + ":" + docling.getPort();
+DoclingServeApi api = DoclingServeClientBuilderFactory.newBuilder().baseUrl(baseUrl).build();
+
+ConvertDocumentRequest request = ConvertDocumentRequest.builder()
+    .source(HttpSource.builder().url(URI.create("https://arxiv.org/pdf/2408.09869")).build())
+    .options(ConvertDocumentOptions.builder()
+        .toFormat(OutputFormat.MARKDOWN)
+        .includeImages(true)
+        .build())
+    .target(InBodyTarget.builder().build())
+    .build();
+
+ConvertDocumentResponse response = api.convertSource(request);
+// Assert on response.getDocument().getMarkdownContent(), errors, timings, etc.
+```
+
+## Configuration
+
+The container is configured via `DoclingServeContainerConfig`. Use its fluent builder to customize:
+
+- Container image (default points to the official GHCR image)
+- Whether to enable the demonstration UI
+- Additional environment variables
+- Startup timeout
+
+```java
+import java.time.Duration;
+import java.util.Map;
+import ai.docling.testcontainers.serve.config.DoclingServeContainerConfig;
+import ai.docling.testcontainers.serve.DoclingServeContainer;
+
+DoclingServeContainerConfig config = DoclingServeContainerConfig.builder()
+    // Override the image if you need a different tag or registry
+    .image("ghcr.io/docling-project/docling-serve:v1.8.0")
+    // Enable the optional web UI served by Docling Serve
+    .enableUi(true)
+    // Pass environment variables to fine‑tune behavior
+    .containerEnv(Map.of(
+        // Example: configure OCR languages or pipeline hints if supported by the server
+        "DOCLING_OCR_LANG", "eng,deu"
+    ))
+    // Increase startup timeout if your CI is slow to pull images
+    .startupTimeout(Duration.ofMinutes(2))
+    .build();
+
+DoclingServeContainer container = new DoclingServeContainer(config);
+```
+
+### Defaults
+
+- Default internal port: `5001` (exposed and mapped automatically)
+- Default image: `ghcr.io/docling-project/docling-serve:<version>`
+- Default startup timeout: 1 minute
+
+## Tips and caveats
+
+- A container runtime (Docker/Podman) must be available to the test process (locally or on CI). For GitHub Actions, consider the official Testcontainers setup docs.
+- Prefer `static` containers for faster test suites; or use reusability where applicable per Testcontainers guidelines.
+- If you run multiple containers, consider a shared `@Testcontainers` test base to avoid repeated pulls.
+- For plain `http://` base URLs, the reference client forces HTTP/1.1 to interoperate smoothly with FastAPI.
+- Clean up resources: JUnit/Testcontainers manages lifecycle automatically for annotated containers. If you manage containers manually, remember to call `start()`/`stop()`.
+
+## Related modules
+
+- API types and request model: [`docling-serve-api`](docling-serve/serve-api.md)
+- Reference HTTP client: [`docling-serve-client`](docling-serve/serve-client.md)

--- a/docs/src/doc/docs/testing.md
+++ b/docs/src/doc/docs/testing.md
@@ -1,1 +1,126 @@
 # Testing
+
+The `docling-testing` area contains tooling used to validate Docling Serve images and to help you test your integration. The main utility today is a small [Quarkus](https://quarkus.io)/[Picocli](https://quarkus.io/guides/picocli) command that automatically verifies multiple Docling Serve versions by:
+
+- Discovering container tags (versions) from a registry (default: GitHub Container Registry)
+- Starting each version with Testcontainers
+- Performing a health check and a real conversion using the reference HTTP client
+- Aggregating results, saving logs and a Markdown report, and optionally opening a GitHub issue when failures occur
+
+If you’re looking to test your application code against a running server during unit/integration tests, consider the Testcontainers module instead:
+- [`docling-testcontainers`](testcontainers.md)
+
+## When to use `docling-testing`
+
+- You want to validate that a range of Docling Serve image tags start correctly and can perform a basic conversion.
+- You need a repeatable way to check compatibility across versions on CI.
+- You want automatic result aggregation and, optionally, automated GitHub issue creation when a regression is detected.
+
+## What’s included
+
+Submodule: `docling-testing/docling-version-tests`
+
+- Runtime: [Quarkus (Picocli) CLI](https://quarkus.io/guides/picocli)
+- Orchestrates Docling Serve containers with Testcontainers
+- Uses the reference client (`docling-serve-client`) to call the Health and Convert endpoints
+- Produces artifacts: logs and a Markdown summary in an output directory
+
+## Prerequisites
+
+- Java 17+
+- Docker or an alternative container runtime compatible with Testcontainers
+- Network access to pull images from your chosen registry (default: `ghcr.io`)
+
+## Run the version tests locally
+
+You can run the CLI directly from the repository using the Quarkus Gradle plugin.
+
+Option A — Dev mode (quick iteration):
+
+```bash
+./gradlew :docling-version-tests:quarkusDev
+```
+
+Option B — Build a runnable JAR and execute it:
+
+```bash
+# Build the application
+./gradlew :docling-version-tests:build
+
+# Run it
+java -jar docling-testing/docling-version-tests/build/quarkus-app/quarkus-run.jar
+```
+
+Notes:
+- The CLI will spin up Docker containers; ensure your user can access the Docker daemon.
+- By default it fetches all version tags for the given image and tests them serially (configurable with `--parallelism`).
+
+## CLI options
+
+These map to the Picocli command `docling-serve-version-tests`.
+
+- `-p, --parallelism` (int, default `1`): How many versions to verify in parallel.
+- `-i, --image` (string, default `docling-project/docling-serve`): The image repository name (without registry and tag).
+- `-r, --registry` (string, default `ghcr.io`): Which registry to query for tags and pull from.
+- `-o, --output` (path, default `results`): Output directory. A timestamped subfolder is created per run.
+- `-t, --tags` (multiple): Explicit list of tags to test. If omitted, the tool fetches all available version tags from the registry.
+- `-g, --create-github-issue` (boolean, default `true`): When enabled, and if configured with credentials, creates/updates a GitHub issue on failures.
+
+Examples:
+
+```bash
+# Test the latest published versions from GHCR, one at a time
+./gradlew :docling-version-tests:quarkusDev
+
+# Test a specific set of tags in parallel
+./gradlew :docling-version-tests:quarkusDev \
+  -p 3 \
+  -t v1.8.0 \
+  -t v1.7.3 \
+  -t v1.6.5
+
+# Save artifacts under a custom directory and disable GitHub issue creation
+./gradlew :docling-version-tests:quarkusDev \
+  -o ./my-results \
+  --no-create-github-issue
+```
+
+## What the tool verifies
+
+For each tag under test, the tool:
+
+1. Starts `ghcr.io/<registry>/<image>:<tag>` with Testcontainers (default internal port 5001).
+2. Checks `/health` using `DoclingServeApi.health()`.
+3. Performs a conversion with `DoclingServeApi.convertSource()` on a simple HTTP source.
+4. Asserts that the response contains no errors and includes expected fields (filename, Markdown, text, JSON content).
+5. Captures server logs and aggregates pass/fail status per tag.
+
+Under the hood, this is implemented in:
+- `ai.docling.client.tester.service.TagsTester` (spins up the container, runs checks)
+- `ai.docling.client.tester.VersionTestsCommand` (parses options, parallelizes work, aggregates results)
+
+## Results and artifacts
+
+At the end of a run, you’ll find a timestamped directory under the output path, for example:
+
+```
+results/
+  results-20250101T121314Z/
+    summary.md           # Markdown summary of tags tested and outcomes
+    <tag>-server.log     # Logs captured from the Docling Serve container for each tag
+    ...
+```
+
+Depending on your configuration, a GitHub issue may be created or updated to include the summary table and failure details.
+
+## CI tips
+
+- Ensure Docker is available to the build agent (for GitHub Actions, see the Testcontainers setup guides).
+- Consider caching Docker layers between runs to speed up tag pulls.
+- Use `--parallelism` prudently on shared or small CI runners to avoid resource contention.
+- If your environment is slow to pull images or start containers, increase the startup timeout via the internal config (the tool already uses a conservative default of 2 minutes per tag).
+
+## Related modules
+
+- Reference HTTP client used by the tool: [`docling-serve-client`](docling-serve/serve-client.md)
+- Testcontainers integration (use this if you want Docling in your own tests): [`docling-testcontainers`](testcontainers.md)

--- a/docs/src/doc/mkdocs.yml
+++ b/docs/src/doc/mkdocs.yml
@@ -54,9 +54,8 @@ theme:
 nav:
   - Home:
     - "Docling Java": index.md
-    - Getting started:
-      - Getting started: getting-started.md
-  - Artifacts:
+    - Getting started: getting-started.md
+  - Modules:
     - Docling Serve:
       - API: docling-serve/serve-api.md
       - Client: docling-serve/serve-client.md


### PR DESCRIPTION
- Added comprehensive new sections for `testing`, `docling-serve-client`, and `docling-serve-api` modules covering usage, installation, and configuration.
- Introduced guides for Testcontainers integration (`docling-testcontainers`) to support end-to-end testing against `docling-serve`.
- Updated `mkdocs` navigation to reflect the expanded structure and resources.