### PR TITLE
ci: Add Discord webhook for release announcements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,7 @@ jobs:
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          JRELEASER_DISCORD_WEBHOOK: ${{ secrets.RELEASES_DISCORD_WEBHOOK }}
           JRELEASER_DRY_RUN: ${{ inputs.dryrun }}
         run: |
           echo "Releasing version ${{ env.PREVIOUS_VERSION }} -> ${{ env.CURRENT_VERSION }}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,13 +81,15 @@ jreleaser {
   }
 
   announce {
-    active = org.jreleaser.model.Active.ALWAYS
+    discord {
+      active = org.jreleaser.model.Active.RELEASE
+    }
 
     discussions {
+      active = org.jreleaser.model.Active.RELEASE
       organization = "docling-project"
       team = "docling-java"
       title = "{{projectNameCapitalized}} {{projectVersion}} released!"
-      message = "🚀 {{projectNameCapitalized}} {{projectVersion}} has been released! {{releaseNotesUrl}}"
     }
   }
 }


### PR DESCRIPTION
Integrate Discord webhook into the JReleaser workflow and configure Discord announcements in the build script.

Fixes #85