### PR TITLE
feat(testcontainers): Show Docling Serve UI

### DIFF
--- a/docling-testcontainers/src/main/java/ai/docling/testcontainers/serve/DoclingServeContainer.java
+++ b/docling-testcontainers/src/main/java/ai/docling/testcontainers/serve/DoclingServeContainer.java
@@ -6,6 +6,8 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+import com.github.dockerjava.api.command.InspectContainerResponse;
+
 import ai.docling.testcontainers.serve.config.DoclingServeContainerConfig;
 
 /**
@@ -59,4 +61,26 @@ public class DoclingServeContainer extends GenericContainer<DoclingServeContaine
   public int getPort() {
     return getMappedPort(DEFAULT_DOCLING_PORT);
   }
+
+  /**
+   * The URL where to access the Docling Serve API.
+   */
+  public String getApiUrl() {
+    return "http://" + getHost() + ":" + getPort();
+  }
+
+  /**
+   * The URL where to access the Docling Serve UI, if enabled.
+   */
+  public String getUiUrl() {
+    return getApiUrl() + "/ui";
+  }
+
+  @Override
+  protected void containerIsStarted(InspectContainerResponse containerInfo) {
+    if (config.enableUi()) {
+      LOG.info(() -> "Docling Serve UI: %s".formatted(getUiUrl()));
+    }
+  }
+
 }


### PR DESCRIPTION
When starting a Docling Server Testcontainer and the UI is enabled, the URL for the UI will now be logged in the console. That's similar to other Testcontainers modules that optionally expose a UI, such as Grafana LGTM.

```log
Docling Serve UI: http://localhost:<port>/ui
```

Furthermore, the `DoclingServeContainer` now provides two additional convenient methods: `getApiUrl()` and `getUiUrl()`.