### PR TITLE
ci: Fix multi-version docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  release:
+    types:
+      - released
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -25,15 +28,32 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    name: Build Docs
+    name: Build/publish Docs
     if: github.repository == 'docling-project/docling-java'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - name: Setup env (release)
+        if: github.event_name == 'release'
+        run: echo "DOCS_ALIAS=release" >> $GITHUB_ENV
+
+      - name: Setup env (other)
+        if: (github.event_name != 'release')
+        run: echo "DOCS_ALIAS=dev" >> $GITHUB_ENV
+
+      - name: Checkout sources
+        if: github.event_name != 'release'
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
+
+      - name: Get release sources
+        if: github.event_name == 'release'
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Setup Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
@@ -57,7 +77,7 @@ jobs:
         run: .github/scripts/get-current-gh-pages.sh
 
       - name: Generate documentation
-        run: ./gradlew --console=plain :docs:build
+        run: ./gradlew --console=plain :docs:build -Pdocs.alias=${{ env.DOCS_ALIAS }}
 
       - name: Setup pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ permissions:
   attestations: write
   id-token: write
   contents: write
-  pages: write
   discussions: write
 
 defaults:
@@ -30,7 +29,8 @@ defaults:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: (github.repository == 'docling-project/docling-java') && ((github.event_name == 'pull_request_target') && (github.event.pull_request.merged == true))
+#    Verifies that the PR was merged into main, that the PR only runs in the docling-java repo (not a fork), and that the PR branch is NOT from a fork.
+    if: (github.event.pull_request.merged == true) && (github.repository == 'docling-project/docling-java') && (github.event.pull_request.head.repo.full_name == 'docling-project/docling-java')
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -62,11 +62,6 @@ jobs:
       - name: Capture current version
         run: echo "CURRENT_VERSION=$(yq '.release.current-version' after/.github/project.yml)" >> $GITHUB_ENV
 
-      - name: Setup Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
-        with:
-          python-version: '3.x'
-
       - name: Setup Java
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
@@ -94,32 +89,6 @@ jobs:
         run: |
           echo "Releasing version ${{ env.PREVIOUS_VERSION }} -> ${{ env.CURRENT_VERSION }}"
           ./gradlew --no-daemon :jreleaserFullRelease
-
-      - name: Build current version docs
-        working-directory: after
-        run: ./gradlew --no-daemon :docs:build
-
-      - name: Build previous version docs
-        working-directory: before
-        run: ./gradlew --no-daemon :docs:build -Pdocs.alias=release -Pdocs.versionsFile=$(realpath ../after/build/mkdocs/versions.json)
-
-      - name: Merge docs together
-        run: |
-          mkdir -p docs
-          cp -vRf after/docs/build/mkdocs docs/
-          cp -vRf before/docs/build/mkdocs docs/
-
-      - name: Setup pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
-
-      - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
-        with:
-          path: docs
-
-      - name: Deploy to GH Pages
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
       # Persist logs
       - name: JReleaser release output


### PR DESCRIPTION
This should fix #88. The challenge will be, though, that it'll take 2 releases for it to sync.

1 release to get the "wiring" in place
1 release to execute the wiring on the previously-released version

This also brings in a guard that _ONLY_ performs the release on a PR merge of `.github/project.yml` if both the HEAD & BASE branches of the PR come from this repo (i.e. not a fork).

This means that only maintainers can create the PR branch.

Fixes #88