### PR TITLE
docs: Update docs build script and configs for `docling-core` artifact

### DIFF
--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -25,7 +25,8 @@ mkdocs {
       "project-artifactId" to "${rootProject.name}",
       "serve-api-artifactId" to project(":docling-serve-api").name,
       "serve-client-artifactId" to project(":docling-serve-client").name,
-      "testcontainers-artifactId" to project(":docling-testcontainers").name
+      "testcontainers-artifactId" to project(":docling-testcontainers").name,
+      "core-artifactId" to project(":docling-core").name
   )
 
   publish {

--- a/docs/src/doc/docs/core.md
+++ b/docs/src/doc/docs/core.md
@@ -16,7 +16,7 @@ Add the dependency to your project.
 
     ``` kotlin
     dependencies {
-      implementation("{{ gradle.project_groupId }}:docling-core:{{ gradle.project_version }}")
+      implementation("{{ gradle.project_groupId }}:{{ gradle.core_artifactId }}:{{ gradle.project_version }}")
     }
     ```
 
@@ -25,7 +25,7 @@ Add the dependency to your project.
     ``` xml
     <dependency>
       <groupId>{{ gradle.project_groupId }}</groupId>
-      <artifactId>docling-core</artifactId>
+      <artifactId>{{ gradle.core_artifactId }}</artifactId>
       <version>{{ gradle.project_version }}</version>
     </dependency>
     ```

--- a/docs/src/doc/mkdocs.yml
+++ b/docs/src/doc/mkdocs.yml
@@ -104,7 +104,7 @@ extra_css:
 extra:
   version:
     provider: mike
-    default: dev
+    default: release
     alias: true
   social:
     - icon: fontawesome/brands/github


### PR DESCRIPTION
Added `docling-core` artifact configuration in `build.gradle.kts`. Updated `mkdocs.yml` to set default version to `release`. Adjusted dependency references in documentation templates to use `core_artifactId`.