### PR TITLE
feat: Add exclude-tags-regex option in version tests

### DIFF
--- a/.github/workflows/version-tests.yml
+++ b/.github/workflows/version-tests.yml
@@ -34,6 +34,10 @@ on:
           If blank, list of tags will be fetched dynamically
         required: false
         type: string
+      excludeTagsRegex:
+        description: A regex to exclude tags from testing. Tags matching this regex will be excluded.
+        required: false
+        type: string
       createGithubIssue:
         description: Create a GitHub issue if any of the tests fail
         required: true
@@ -86,6 +90,7 @@ jobs:
           echo "IMAGE=${{ inputs.image || 'docling-project/docling-serve' }}" >> $GITHUB_ENV
           echo "REGISTRY=${{ inputs.registry || 'ghcr.io' }}" >> $GITHUB_ENV
           echo "OUTPUT_DIR=${{ inputs.outputDir || 'results' }}" >> $GITHUB_ENV
+          echo "EXCLUDE_TAGS_REGEX=${{ inputs.excludeTagsRegex || '^v0.*' }}" >> $GITHUB_ENV
 
       - name: Set up Java ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
@@ -115,6 +120,7 @@ jobs:
             -i ${{ env.IMAGE }} \
             -r ${{ env.REGISTRY }} \
             -o ${{ env.OUTPUT_DIR }} \
+            -e ${{ env.EXCLUDE_TAGS_REGEX }} \
             --cleanup-container-images \
             ${{ env.TAGS }} ${{ env.CREATE_GITHUB_ISSUE_FLAG }}
 

--- a/docling-testing/docling-version-tests/src/test/java/ai/docling/client/tester/VersionTestsCommandOptionTests.java
+++ b/docling-testing/docling-version-tests/src/test/java/ai/docling/client/tester/VersionTestsCommandOptionTests.java
@@ -43,6 +43,16 @@ class VersionTestsCommandOptionTests {
   }
 
   @Test
+  @Launch({ "-o", "build/results", "-e", "^v0.*" })
+  void noTagsProvidedWithExclusionFilter(LaunchResult result) {
+    assertThat(result.getOutput())
+        .isNotNull()
+        .isNotEmpty()
+        .contains("Going to test tags: [v1.0.0, v1.0.1, v1.1.0, v1.2.0, v1.2.1, v1.2.2, v1.3.0, v1.3.1, v1.4.0, v1.4.1, v1.5.0, v1.5.1, v1.6.0, v1.7.0, v1.7.1, v1.7.2]")
+        .contains("GitHub issue creation is disabled. Skipping.");
+  }
+
+  @Test
   @Launch({ "-o", "build/results" })
   void dontCreateGithubIssue(LaunchResult result) {
     assertThat(result.getOutput())


### PR DESCRIPTION
Added `--exclude-tags-regex` option to filter out tags during version testing. Updated workflows and tests to support the new feature.

Fixes #125