### PR TITLE
fix: Add custom Duration serializers with ChronoUnit support

### DIFF
--- a/docling-core/build.gradle.kts
+++ b/docling-core/build.gradle.kts
@@ -15,6 +15,11 @@ dependencies {
   compileOnly(libs.jackson.annotations)
   compileOnly(libs.jackson.databind)
   compileOnly(libs.jackson2.databind)
+
+  testImplementation(platform(libs.jackson.bom))
+  testImplementation(libs.jackson.annotations)
+  testImplementation(libs.jackson.databind)
+  testImplementation(libs.jackson2.databind)
 }
 
 tasks.withType<Javadoc> {

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/convert/request/options/ConvertDocumentOptions.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/convert/request/options/ConvertDocumentOptions.java
@@ -1,6 +1,7 @@
 package ai.docling.serve.api.convert.request.options;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.jspecify.annotations.Nullable;
@@ -9,6 +10,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import ai.docling.serve.api.serialization.DurationSerializationFormat;
+import ai.docling.serve.api.serialization.Jackson2DurationSerializer;
+import ai.docling.serve.api.serialization.Jackson3DurationSerializer;
 
 /**
  * Options for configuring the document conversion process with Docling.
@@ -73,6 +79,9 @@ public class ConvertDocumentOptions {
   private List<Integer> pageRange;
 
   @JsonProperty("document_timeout")
+  @JsonSerialize(using = Jackson2DurationSerializer.class)
+  @tools.jackson.databind.annotation.JsonSerialize(using = Jackson3DurationSerializer.class)
+  @DurationSerializationFormat(ChronoUnit.SECONDS)
   @Nullable
   private Duration documentTimeout;
 

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/convert/request/options/PictureDescriptionApi.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/convert/request/options/PictureDescriptionApi.java
@@ -2,6 +2,7 @@ package ai.docling.serve.api.convert.request.options;
 
 import java.net.URI;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -10,6 +11,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import ai.docling.serve.api.serialization.DurationSerializationFormat;
+import ai.docling.serve.api.serialization.Jackson2DurationSerializer;
+import ai.docling.serve.api.serialization.Jackson3DurationSerializer;
 
 /**
  * Configuration options for picture description API integration.
@@ -38,6 +44,9 @@ public class PictureDescriptionApi {
   private Map<String, Object> params;
 
   @JsonProperty("timeout")
+  @JsonSerialize(using = Jackson2DurationSerializer.class)
+  @tools.jackson.databind.annotation.JsonSerialize(using = Jackson3DurationSerializer.class)
+  @DurationSerializationFormat(ChronoUnit.SECONDS)
   @Nullable
   private Duration timeout;
 

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/convert/request/options/VlmModelApi.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/convert/request/options/VlmModelApi.java
@@ -2,6 +2,7 @@ package ai.docling.serve.api.convert.request.options;
 
 import java.net.URI;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -10,6 +11,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import ai.docling.serve.api.serialization.DurationSerializationFormat;
+import ai.docling.serve.api.serialization.Jackson2DurationSerializer;
+import ai.docling.serve.api.serialization.Jackson3DurationSerializer;
 
 /**
  * API details for using a vision-language model for the VLM pipeline.
@@ -36,6 +42,9 @@ public class VlmModelApi {
     private Map<String, Object> params;
 
     @JsonProperty("timeout")
+    @JsonSerialize(using = Jackson2DurationSerializer.class)
+    @tools.jackson.databind.annotation.JsonSerialize(using = Jackson3DurationSerializer.class)
+    @DurationSerializationFormat(ChronoUnit.SECONDS)
     @Nullable
     private Duration timeout;
 

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/serialization/DurationSerializationFormat.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/serialization/DurationSerializationFormat.java
@@ -1,0 +1,41 @@
+package ai.docling.serve.api.serialization;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Annotation to specify the formatting unit for durations.
+ * This annotation can be applied to fields to indicate the {@link ChronoUnit}
+ * that governs how durations should be interpreted or formatted.
+ * <p>
+ *   You would use it like this:
+ *   <pre>{@code
+ *   @JsonProperty("timeout")
+ *   @JsonSerialize(using = Jackson2DurationSerializer.class)
+ *   @tools.jackson.databind.annotation.JsonSerialize(using = Jackson3DurationSerializer.class)
+ *   @DurationSerializationFormat(ChronoUnit.SECONDS)
+ *   @Nullable
+ *   private Duration timeout;
+ *   }
+ *   </pre>
+ * </p>
+ * @see Jackson2DurationSerializer
+ * @see Jackson3DurationSerializer
+ */
+@Inherited
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface DurationSerializationFormat {
+  /**
+   * Specifies the unit of time to be used for formatting durations.
+   *
+   * @return the {@link ChronoUnit} representing the unit of time for formatting durations
+   */
+  ChronoUnit value();
+}

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/serialization/Jackson2DurationSerializer.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/serialization/Jackson2DurationSerializer.java
@@ -1,0 +1,71 @@
+package ai.docling.serve.api.serialization;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+
+public class Jackson2DurationSerializer extends JsonSerializer<Duration> implements ContextualSerializer {
+  private final ChronoUnit unit;
+
+  public Jackson2DurationSerializer() {
+    this(ChronoUnit.SECONDS);
+  }
+
+  public Jackson2DurationSerializer(ChronoUnit unit) {
+    this.unit = unit;
+  }
+
+  @Override
+  public void serialize(Duration value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    if (value == null) {
+      gen.writeNull();
+      return;
+    }
+
+    switch (this.unit) {
+      case NANOS:
+        gen.writeNumber(value.toNanos());
+        break;
+
+      case MICROS:
+        gen.writeNumber(value.toNanos() / 1000);
+        break;
+
+      case MILLIS:
+        gen.writeNumber(value.toMillis());
+        break;
+
+      case MINUTES:
+        gen.writeNumber(value.toMinutes());
+        break;
+
+      case HOURS:
+        gen.writeNumber(value.toHours());
+        break;
+
+      case DAYS:
+        gen.writeNumber(value.toDays());
+        break;
+
+      case SECONDS:
+      default:
+        gen.writeNumber(value.getSeconds());
+        break;
+    }
+  }
+
+  @Override
+  public JsonSerializer<?> createContextual(SerializerProvider prov, BeanProperty property) {
+    return Optional.ofNullable(property)
+        .map(p -> p.getAnnotation(DurationSerializationFormat.class))
+        .map(annotation -> new Jackson2DurationSerializer(annotation.value()))
+        .orElse(this);
+  }
+}

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/serialization/Jackson3DurationSerializer.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/serialization/Jackson3DurationSerializer.java
@@ -1,0 +1,70 @@
+package ai.docling.serve.api.serialization;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.BeanProperty;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+
+public class Jackson3DurationSerializer extends ValueSerializer<Duration> {
+  private final ChronoUnit unit;
+
+  public Jackson3DurationSerializer(ChronoUnit unit) {
+    this.unit = unit;
+  }
+
+  public Jackson3DurationSerializer() {
+    this(ChronoUnit.SECONDS);
+  }
+
+  @Override
+  public void serialize(Duration value, JsonGenerator gen, SerializationContext ctxt) throws JacksonException {
+    if (value == null) {
+      gen.writeNull();
+      return;
+    }
+
+    switch (this.unit) {
+      case NANOS:
+        gen.writeNumber(value.toNanos());
+        break;
+
+      case MICROS:
+        gen.writeNumber(value.toNanos() / 1000);
+        break;
+
+      case MILLIS:
+        gen.writeNumber(value.toMillis());
+        break;
+
+      case MINUTES:
+        gen.writeNumber(value.toMinutes());
+        break;
+
+      case HOURS:
+        gen.writeNumber(value.toHours());
+        break;
+
+      case DAYS:
+        gen.writeNumber(value.toDays());
+        break;
+
+      case SECONDS:
+      default:
+        gen.writeNumber(value.getSeconds());
+        break;
+    }
+  }
+
+  @Override
+  public ValueSerializer<?> createContextual(SerializationContext ctxt, BeanProperty property) {
+    return Optional.ofNullable(property)
+        .map(p -> p.getAnnotation(DurationSerializationFormat.class))
+        .map(annotation -> new Jackson3DurationSerializer(annotation.value()))
+        .orElse(this);
+  }
+}

--- a/docling-serve/docling-serve-client/build.gradle.kts
+++ b/docling-serve/docling-serve-client/build.gradle.kts
@@ -8,12 +8,16 @@ description = "Docling Serve Client"
 dependencies {
   api(project(":docling-serve-api"))
   api(libs.slf4j.api)
-  implementation(platform(libs.jackson.bom))
-  implementation(libs.jackson.databind)
-  implementation(libs.jackson2.databind)
+  compileOnly(platform(libs.jackson.bom))
+  compileOnly(libs.jackson.databind)
+  compileOnly(libs.jackson2.databind)
 
   testImplementation(platform(libs.testcontainers.bom))
   testImplementation(libs.testcontainers.junit.jupiter)
   testImplementation(project(":docling-testcontainers"))
   testImplementation(libs.slf4j.simple)
+
+  testImplementation(platform(libs.jackson.bom))
+  testImplementation(libs.jackson.databind)
+  testImplementation(libs.jackson2.databind)
 }

--- a/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/AbstractDoclingServeClientTests.java
+++ b/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/AbstractDoclingServeClientTests.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
 
@@ -14,8 +15,8 @@ import ai.docling.api.core.DoclingDocument;
 import ai.docling.api.core.DoclingDocument.DocItemLabel;
 import ai.docling.serve.api.DoclingServeApi;
 import ai.docling.serve.api.chunk.request.HierarchicalChunkDocumentRequest;
-import ai.docling.serve.api.chunk.request.options.HierarchicalChunkerOptions;
 import ai.docling.serve.api.chunk.request.HybridChunkDocumentRequest;
+import ai.docling.serve.api.chunk.request.options.HierarchicalChunkerOptions;
 import ai.docling.serve.api.chunk.request.options.HybridChunkerOptions;
 import ai.docling.serve.api.chunk.response.Chunk;
 import ai.docling.serve.api.chunk.response.ChunkDocumentResponse;
@@ -84,6 +85,7 @@ abstract class AbstractDoclingServeClientTests {
             .base64String(Base64.getEncoder().encodeToString(fileResource))
             .build()
         )
+
         .build();
 
     ConvertDocumentResponse response = getDoclingClient().convertSource(request);
@@ -106,6 +108,7 @@ abstract class AbstractDoclingServeClientTests {
         .doOcr(true)
         .includeImages(true)
         .tableMode(TableFormerMode.FAST)
+        .documentTimeout(Duration.ofMinutes(1))
         .build();
 
     ConvertDocumentRequest request = ConvertDocumentRequest.builder()


### PR DESCRIPTION
Introduced `Jackson2DurationSerializer` and `Jackson3DurationSerializer` to allow custom serialization of `Duration` fields based on `ChronoUnit`. Updated relevant API options (`ConvertDocumentOptions`, `VlmModelApi`, `PictureDescriptionApi`) to use the new serializers. Adjusted Gradle test dependencies to include required Jackson libraries.

Fixes #152