### PR TITLE
fix: Rename JSON property 'options' to 'convert_options' in chunk document requests

### DIFF
--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/chunk/request/HierarchicalChunkDocumentRequest.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/chunk/request/HierarchicalChunkDocumentRequest.java
@@ -31,7 +31,7 @@ public class HierarchicalChunkDocumentRequest {
   @lombok.Singular
   private List<Source> sources;
 
-  @JsonProperty("options")
+  @JsonProperty("convert_options")
   @lombok.NonNull
   @lombok.Builder.Default
   private ConvertDocumentOptions options = ConvertDocumentOptions.builder().build();

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/chunk/request/HybridChunkDocumentRequest.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/chunk/request/HybridChunkDocumentRequest.java
@@ -31,7 +31,7 @@ public class HybridChunkDocumentRequest {
   @lombok.Singular
   private List<Source> sources;
 
-  @JsonProperty("options")
+  @JsonProperty("convert_options")
   @lombok.NonNull
   @lombok.Builder.Default
   private ConvertDocumentOptions options = ConvertDocumentOptions.builder().build();


### PR DESCRIPTION
Updated `@JsonProperty` annotation in `HierarchicalChunkDocumentRequest` and `HybridChunkDocumentRequest` to rename `options` to `convert_options` per the spec.