### PR TITLE
build: Remove Docling Java Bot from release notes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ jreleaser {
         }
         hide {
           categories = listOf("merge")
-          contributors = listOf("GitHub", "dependabot")
+          contributors = listOf("GitHub", "dependabot", "docling-java-ops")
         }
         extraProperties.put("categorizeScopes", true)
       }


### PR DESCRIPTION
I had previously excluded the GitHub and Dependabot bots from the release notes. Didn't think about the Docling Java Bot. This change removes it from future release notes.

<img width="514" height="203" alt="Screenshot 2025-12-08 at 19 27 38" src="https://github.com/user-attachments/assets/abb49aee-f326-4fd0-8ddd-ff5d6f75882b" />
