### PR TITLE
refactor: Move core package from `api.core` to `core`

### DIFF
--- a/docling-core/src/main/java/ai/docling/core/DoclingDocument.java
+++ b/docling-core/src/main/java/ai/docling/core/DoclingDocument.java
@@ -1,8 +1,10 @@
-package ai.docling.api.core;
+package ai.docling.core;
 
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -11,8 +13,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.Nulls;
-
-import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a document processed by the Docling service with its structure,

--- a/docling-core/src/main/java/ai/docling/core/package-info.java
+++ b/docling-core/src/main/java/ai/docling/core/package-info.java
@@ -2,6 +2,6 @@
  * Docling Core API.
  */
 @NullMarked
-package ai.docling.api.core;
+package ai.docling.core;
 
 import org.jspecify.annotations.NullMarked;

--- a/docling-core/src/test/java/ai/docling/core/DoclingDocumentTests.java
+++ b/docling-core/src/test/java/ai/docling/core/DoclingDocumentTests.java
@@ -1,11 +1,11 @@
-package ai.docling.api.core;
+package ai.docling.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-import ai.docling.api.core.DoclingDocument.DocItemLabel;
-import ai.docling.api.core.DoclingDocument.TitleItem;
+import ai.docling.core.DoclingDocument.DocItemLabel;
+import ai.docling.core.DoclingDocument.TitleItem;
 
 /**
  * Unit tests for {@link DoclingDocument}.

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/chunk/response/ExportDocumentResponse.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/chunk/response/ExportDocumentResponse.java
@@ -5,7 +5,7 @@ import org.jspecify.annotations.Nullable;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import ai.docling.api.core.DoclingDocument;
+import ai.docling.core.DoclingDocument;
 
 /**
  * Content of the original converted document, before getting chunked.

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/convert/response/DocumentResponse.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/convert/response/DocumentResponse.java
@@ -5,7 +5,7 @@ import org.jspecify.annotations.Nullable;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import ai.docling.api.core.DoclingDocument;
+import ai.docling.core.DoclingDocument;
 
 /**
  * A simple mutable POJO representing the converted document returned by the

--- a/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/convert/response/ConvertDocumentResponseTests.java
+++ b/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/convert/response/ConvertDocumentResponseTests.java
@@ -9,8 +9,8 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import ai.docling.api.core.DoclingDocument;
-import ai.docling.api.core.DoclingDocument.TitleItem;
+import ai.docling.core.DoclingDocument;
+import ai.docling.core.DoclingDocument.TitleItem;
 
 /**
  * Unit tests for {@link ConvertDocumentResponse}.

--- a/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/convert/response/DocumentResponseTests.java
+++ b/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/convert/response/DocumentResponseTests.java
@@ -7,9 +7,9 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import ai.docling.api.core.DoclingDocument;
-import ai.docling.api.core.DoclingDocument.DocItemLabel;
-import ai.docling.api.core.DoclingDocument.TitleItem;
+import ai.docling.core.DoclingDocument;
+import ai.docling.core.DoclingDocument.DocItemLabel;
+import ai.docling.core.DoclingDocument.TitleItem;
 
 /**
  * Unit tests for {@link DocumentResponse}.

--- a/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/AbstractDoclingServeClientTests.java
+++ b/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/AbstractDoclingServeClientTests.java
@@ -11,8 +11,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import ai.docling.api.core.DoclingDocument;
-import ai.docling.api.core.DoclingDocument.DocItemLabel;
+import ai.docling.core.DoclingDocument;
+import ai.docling.core.DoclingDocument.DocItemLabel;
 import ai.docling.serve.api.DoclingServeApi;
 import ai.docling.serve.api.chunk.request.HierarchicalChunkDocumentRequest;
 import ai.docling.serve.api.chunk.request.HybridChunkDocumentRequest;

--- a/docling-testing/docling-version-tests/src/main/java/ai/docling/client/tester/service/TagsTester.java
+++ b/docling-testing/docling-version-tests/src/main/java/ai/docling/client/tester/service/TagsTester.java
@@ -14,7 +14,11 @@ import org.testcontainers.DockerClientFactory;
 
 import io.quarkus.logging.Log;
 
-import ai.docling.api.core.DoclingDocument;
+import ai.docling.client.tester.domain.TagTestResult;
+import ai.docling.client.tester.domain.TagTestResult.Result;
+import ai.docling.client.tester.domain.TagsTestRequest;
+import ai.docling.client.tester.domain.TagsTestResults;
+import ai.docling.core.DoclingDocument;
 import ai.docling.serve.api.DoclingServeApi;
 import ai.docling.serve.api.convert.request.ConvertDocumentRequest;
 import ai.docling.serve.api.convert.request.options.ConvertDocumentOptions;
@@ -24,10 +28,6 @@ import ai.docling.serve.api.convert.response.ConvertDocumentResponse;
 import ai.docling.serve.api.convert.response.DocumentResponse;
 import ai.docling.serve.api.health.HealthCheckResponse;
 import ai.docling.serve.client.DoclingServeClientBuilderFactory;
-import ai.docling.client.tester.domain.TagTestResult;
-import ai.docling.client.tester.domain.TagTestResult.Result;
-import ai.docling.client.tester.domain.TagsTestRequest;
-import ai.docling.client.tester.domain.TagsTestResults;
 import ai.docling.testcontainers.serve.DoclingServeContainer;
 import ai.docling.testcontainers.serve.config.DoclingServeContainerConfig;
 


### PR DESCRIPTION
Fixes #166