### PR TITLE
refactor: Refactor clear and task APIs to utilize request objects

### DIFF
--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/DoclingServeClearApi.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/DoclingServeClearApi.java
@@ -1,9 +1,6 @@
 package ai.docling.serve.api;
 
-import java.time.Duration;
-
-import org.jspecify.annotations.Nullable;
-
+import ai.docling.serve.api.clear.request.ClearRequest;
 import ai.docling.serve.api.clear.response.ClearResponse;
 
 /**
@@ -14,15 +11,6 @@ import ai.docling.serve.api.clear.response.ClearResponse;
  */
 public interface DoclingServeClearApi {
   /**
-   * Represents the default duration used as a threshold for clearing stale results
-   * or data in the Docling Serve Clear API. Results older than this duration
-   * are considered stale and may be subject to cleanup.
-   *
-   * The value is predefined as 1 hour (3600 seconds).
-   */
-  Duration DEFAULT_OLDER_THAN = Duration.ofSeconds(3600);
-
-  /**
    * Clears all registered converters associated with the API.
    * This method removes any previously configured or cached converters,
    * effectively resetting the converter state to an uninitialized state.
@@ -31,22 +19,15 @@ public interface DoclingServeClearApi {
   ClearResponse clearConverters();
 
   /**
-   * Clears stored results that are older than the specified duration threshold.
-   * This method is used for housekeeping to remove stale or outdated data from the system.
+   * Clears stored results based on the specified {@link ClearRequest}.
+   * This method removes results that match the criteria provided in the
+   * request, such as results older than a specified duration.
    *
-   * @param olderThen the duration threshold; only results older than this duration will be cleared.
-   * @return a {@link ClearResponse} object containing the status of the clear operation.
+   * @param request an instance of {@link ClearRequest} containing the criteria
+   *                for clearing stored results, including the duration threshold
+   *                or other parameters.
+   * @return a {@link ClearResponse} object indicating the status of the clear
+   *         operation, such as success or failure.
    */
-  ClearResponse clearResults(@Nullable Duration olderThen);
-
-  /**
-   * Clears stored results that are older than the default duration threshold.
-   * This method uses the pre-defined {@code DEFAULT_OLDER_THAN} as the threshold
-   * to determine which results are considered stale and should be removed.
-   *
-   * @return a {@link ClearResponse} object containing the status of the clear operation.
-   */
-  default ClearResponse clearResults() {
-    return clearResults(DEFAULT_OLDER_THAN);
-  }
+  ClearResponse clearResults(ClearRequest request);
 }

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/clear/request/ClearRequest.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/clear/request/ClearRequest.java
@@ -1,0 +1,33 @@
+package ai.docling.serve.api.clear.request;
+
+import java.time.Duration;
+
+/**
+ * Represents a request to clear stale data via the Docling Serve Clear API.
+ * This class provides a mechanism to specify a threshold duration, after which data
+ * is considered stale and eligible for cleanup.
+ *
+ * The {@code olderThen} field specifies the duration threshold, with a default
+ * value of {@link #DEFAULT_OLDER_THAN}, predefined as 1 hour (3600 seconds).
+ * This default can be overridden using the builder or by explicitly passing a custom
+ * duration at runtime.
+ *
+ * Instances of this class are immutable and can be created or modified through its builder.
+ */
+@lombok.Builder(toBuilder = true)
+@lombok.Getter
+@lombok.ToString
+public class ClearRequest {
+  /**
+   * Represents the default duration used as a threshold for clearing stale results
+   * or data in the Docling Serve Clear API. Results older than this duration
+   * are considered stale and may be subject to cleanup.
+   *
+   * The value is predefined as 1 hour (3600 seconds).
+   */
+  public static final Duration DEFAULT_OLDER_THAN = Duration.ofSeconds(3600);
+
+  @lombok.NonNull
+  @lombok.Builder.Default
+  private Duration olderThen = DEFAULT_OLDER_THAN;
+}

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/clear/request/package-info.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/clear/request/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package ai.docling.serve.api.clear.request;
+
+import org.jspecify.annotations.NullMarked;

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/task/request/TaskResultRequest.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/task/request/TaskResultRequest.java
@@ -1,0 +1,21 @@
+package ai.docling.serve.api.task.request;
+
+/**
+ * Represents a request to retrieve the result of a task.
+ *
+ * This class is used to encapsulate the necessary information required to
+ * request the result corresponding to the task identified by its unique task ID.
+ * Instances of this class are immutable and can be built using the provided
+ * builder methods.
+ *
+ * Attributes:
+ * - `taskId`: The unique identifier of the task whose result is being requested.
+ *             This field is mandatory and must not be null.
+ */
+@lombok.Builder(toBuilder = true)
+@lombok.Getter
+@lombok.ToString
+public class TaskResultRequest {
+  @lombok.NonNull
+  private String taskId;
+}

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/task/request/TaskStatusPollRequest.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/task/request/TaskStatusPollRequest.java
@@ -1,0 +1,42 @@
+package ai.docling.serve.api.task.request;
+
+import java.time.Duration;
+
+/**
+ * Represents a request for polling the status of a task.
+ *
+ * This class encapsulates the information required to poll the status of a specific task.
+ * It includes the unique task identifier and an optional wait time between consecutive
+ * polling attempts. Instances of this class are immutable and can be built using the
+ * provided builder methods.
+ *
+ * Attributes:
+ * - `DEFAULT_STATUS_POLL_WAIT_TIME`: Specifies the default value for the wait time
+ *   between polling attempts. By default, this is set to {@link Duration#ZERO}, indicating
+ *   no delay between consecutive polling attempts.
+ * - `taskId`: The unique identifier of the task whose status is being polled. This field is
+ *   mandatory and must not be null.
+ * - `waitTime`: The duration to wait between consecutive polling attempts. If not explicitly
+ *   set, it defaults to {@link #DEFAULT_STATUS_POLL_WAIT_TIME}.
+ */
+@lombok.Builder(toBuilder = true)
+@lombok.Getter
+@lombok.ToString
+public class TaskStatusPollRequest {
+  /**
+   * The default wait time between status polling attempts for a task.
+   * <p>
+   * This value is used when no explicit wait time is specified in a
+   * {@code TaskStatusPollRequest} instance. It is set to {@link Duration#ZERO},
+   * meaning there is no delay by default between consecutive polling attempts.
+   * </p>
+   */
+  public static final Duration DEFAULT_STATUS_POLL_WAIT_TIME = Duration.ZERO;
+
+  @lombok.NonNull
+  private String taskId;
+
+  @lombok.NonNull
+  @lombok.Builder.Default
+  private Duration waitTime = DEFAULT_STATUS_POLL_WAIT_TIME;
+}

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/task/request/package-info.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/task/request/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * The Docling task api
+ */
+@NullMarked
+package ai.docling.serve.api.task.request;
+
+import org.jspecify.annotations.NullMarked;

--- a/docling-serve/docling-serve-api/src/main/java/module-info.java
+++ b/docling-serve/docling-serve-api/src/main/java/module-info.java
@@ -27,9 +27,11 @@ open module ai.docling.serve.api {
   exports ai.docling.serve.api.convert.response;
 
   // Clear API
+  exports ai.docling.serve.api.clear.request;
   exports ai.docling.serve.api.clear.response;
 
   // Task API
+  exports ai.docling.serve.api.task.request;
   exports ai.docling.serve.api.task.response;
 
   // Serialization helpers

--- a/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/clear/request/ClearRequestTests.java
+++ b/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/clear/request/ClearRequestTests.java
@@ -1,0 +1,25 @@
+package ai.docling.serve.api.clear.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+class ClearRequestTests {
+  @Test
+  void nullOlderThen() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> ClearRequest.builder().olderThen(null).build())
+        .withMessage("olderThen is marked non-null but is null");
+  }
+
+  @Test
+  void defaultOlderThen() {
+    assertThat(ClearRequest.builder().build())
+        .isNotNull()
+        .extracting(ClearRequest::getOlderThen)
+        .asInstanceOf(InstanceOfAssertFactories.DURATION)
+        .isEqualByComparingTo(ClearRequest.DEFAULT_OLDER_THAN);
+  }
+}

--- a/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/task/request/TaskResultRequestTests.java
+++ b/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/task/request/TaskResultRequestTests.java
@@ -1,0 +1,21 @@
+package ai.docling.serve.api.task.request;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.Test;
+
+class TaskResultRequestTests {
+  @Test
+  void nullTaskId() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> TaskResultRequest.builder().taskId(null).build())
+        .withMessage("taskId is marked non-null but is null");
+  }
+
+  @Test
+  void noTaskId() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> TaskResultRequest.builder().build())
+        .withMessage("taskId is marked non-null but is null");
+  }
+}

--- a/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/task/request/TaskStatusPollRequestTests.java
+++ b/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/task/request/TaskStatusPollRequestTests.java
@@ -1,0 +1,39 @@
+package ai.docling.serve.api.task.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+class TaskStatusPollRequestTests {
+  @Test
+  void nullTaskId() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> TaskStatusPollRequest.builder().taskId(null).build())
+        .withMessage("taskId is marked non-null but is null");
+  }
+
+  @Test
+  void noTaskId() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> TaskStatusPollRequest.builder().build())
+        .withMessage("taskId is marked non-null but is null");
+  }
+
+  @Test
+  void nullWaitTime() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> TaskStatusPollRequest.builder().waitTime(null).build())
+        .withMessage("waitTime is marked non-null but is null");
+  }
+
+  @Test
+  void defaultWaitTime() {
+    assertThat(TaskStatusPollRequest.builder().taskId("1").build())
+        .isNotNull()
+        .extracting(TaskStatusPollRequest::getWaitTime)
+        .asInstanceOf(InstanceOfAssertFactories.DURATION)
+        .isEqualByComparingTo(TaskStatusPollRequest.DEFAULT_STATUS_POLL_WAIT_TIME);
+  }
+}

--- a/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/ClearOperations.java
+++ b/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/ClearOperations.java
@@ -1,12 +1,9 @@
 package ai.docling.serve.client;
 
-import java.time.Duration;
-import java.util.Optional;
-
-import org.jspecify.annotations.Nullable;
-
 import ai.docling.serve.api.DoclingServeClearApi;
+import ai.docling.serve.api.clear.request.ClearRequest;
 import ai.docling.serve.api.clear.response.ClearResponse;
+import ai.docling.serve.api.util.ValidationUtils;
 
 /**
  * Base class for clear API operations. Provides functionality for managing and cleaning up
@@ -27,17 +24,17 @@ final class ClearOperations implements DoclingServeClearApi {
   }
 
   /**
-   * Clears the results stored by the service that are older than the specified duration.
+   * Clears stale results retained by the service, based on the specified threshold duration.
+   * Results older than the duration specified in the {@link ClearRequest} parameter will be removed.
    *
-   * @param olderThen the {@link Duration} indicating the age threshold. Results older than
-   *                  this duration will be cleared.
-   * @return a {@link ClearResponse} containing information about the outcome of the clear operation.
+   * @param request the {@link ClearRequest} object containing the threshold duration for clearing results;
+   *                must not be null.
+   * @return a {@link ClearResponse} object representing the result of the clear operation,
+   *         including the status of the operation.
    */
-  public ClearResponse clearResults(@Nullable Duration olderThen) {
-    var olderThenSeconds = Optional.ofNullable(olderThen)
-        .orElse(DEFAULT_OLDER_THAN)
-        .toSeconds();
+  public ClearResponse clearResults(ClearRequest request) {
+    ValidationUtils.ensureNotNull(request, "request");
 
-    return this.httpOperations.executeGet("/v1/clear/results?older_then=%d".formatted(olderThenSeconds), ClearResponse.class);
+    return this.httpOperations.executeGet("/v1/clear/results?older_then=%d".formatted(request.getOlderThen().toSeconds()), ClearResponse.class);
   }
 }

--- a/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/DoclingServeClient.java
+++ b/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/DoclingServeClient.java
@@ -12,12 +12,10 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.ByteBuffer;
-import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Flow.Subscriber;
 
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,10 +28,13 @@ import ai.docling.serve.api.DoclingServeTaskApi;
 import ai.docling.serve.api.chunk.request.HierarchicalChunkDocumentRequest;
 import ai.docling.serve.api.chunk.request.HybridChunkDocumentRequest;
 import ai.docling.serve.api.chunk.response.ChunkDocumentResponse;
+import ai.docling.serve.api.clear.request.ClearRequest;
 import ai.docling.serve.api.clear.response.ClearResponse;
 import ai.docling.serve.api.convert.request.ConvertDocumentRequest;
 import ai.docling.serve.api.convert.response.ConvertDocumentResponse;
 import ai.docling.serve.api.health.HealthCheckResponse;
+import ai.docling.serve.api.task.request.TaskResultRequest;
+import ai.docling.serve.api.task.request.TaskStatusPollRequest;
 import ai.docling.serve.api.task.response.TaskStatusPollResponse;
 
 /**
@@ -221,18 +222,18 @@ public abstract class DoclingServeClient extends HttpOperations implements Docli
   }
 
   @Override
-  public TaskStatusPollResponse pollTaskStatus(String taskId, @Nullable Duration waitTime) {
-    return this.taskOps.pollTaskStatus(taskId, waitTime);
+  public TaskStatusPollResponse pollTaskStatus(TaskStatusPollRequest request) {
+    return this.taskOps.pollTaskStatus(request);
   }
 
   @Override
-  public ConvertDocumentResponse convertTaskResult(String taskId) {
-    return this.taskOps.convertTaskResult(taskId);
+  public ConvertDocumentResponse convertTaskResult(TaskResultRequest request) {
+    return this.taskOps.convertTaskResult(request);
   }
 
   @Override
-  public ChunkDocumentResponse chunkTaskResult(String taskId) {
-    return this.taskOps.chunkTaskResult(taskId);
+  public ChunkDocumentResponse chunkTaskResult(TaskResultRequest request) {
+    return this.taskOps.chunkTaskResult(request);
   }
 
   @Override
@@ -241,8 +242,8 @@ public abstract class DoclingServeClient extends HttpOperations implements Docli
   }
 
   @Override
-  public ClearResponse clearResults(Duration olderThen) {
-    return this.clearOps.clearResults(olderThen);
+  public ClearResponse clearResults(ClearRequest request) {
+    return this.clearOps.clearResults(request);
   }
 
   private class LoggingBodyPublisher<T> implements BodyPublisher {


### PR DESCRIPTION
I decided to go back to encapsulating everything to do with a request into a request object.

Doing it the other way just makes method signatures too brittle and open to breaking changes.