### PR TITLE
feat: Introduce API extension point and enhance builder usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,17 @@ This project provides the following artifacts:
 
 ## Getting started
 
-Use `DoclingServeApi.convertSource()` to convert individual documents. For example:
+Use `DoclingServeApi.convertSource()` to convert individual documents (make sure both `docling-serve-api` and `docling-serve-client` are on your classpath).
+
+For example:
 
 ```java
 import ai.docling.serve.api.DoclingServeApi;
 import ai.docling.serve.api.convert.request.ConvertDocumentRequest;
 import ai.docling.serve.api.convert.request.source.HttpSource;
 import ai.docling.serve.api.convert.response.ConvertDocumentResponse;
-import ai.docling.serve.client.DoclingServeClientBuilderFactory;
 
-DoclingServeApi doclingServeApi = DoclingServeClientBuilderFactory.newBuilder()
+DoclingServeApi doclingServeApi = DoclingServeApi.builder()
     .baseUrl("<location of docling serve instance>")
     .build();
 
@@ -124,5 +125,3 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!
-
-### IBM ❤️ Open Source AI

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/spi/DoclingServeApiBuilderFactory.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/spi/DoclingServeApiBuilderFactory.java
@@ -1,0 +1,20 @@
+package ai.docling.serve.api.spi;
+
+import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.DoclingServeApi.DoclingApiBuilder;
+
+/**
+ * Factory interface for creating builder instances to construct implementations of {@link DoclingServeApi}.
+ */
+public interface DoclingServeApiBuilderFactory {
+  /**
+   * Retrieves a builder instance for constructing implementations of {@link DoclingServeApi}.
+   * The returned builder allows customization of various configurations and properties
+   * before creating an instance of the API.
+   *
+   * @param <T> the type of the {@link DoclingServeApi} implementation being built
+   * @param <B> the type of the concrete builder implementation
+   * @return a builder of type {@code B}, which is used to construct instances of {@code T}
+   */
+  <T extends DoclingServeApi, B extends DoclingApiBuilder<T, B>> B getBuilder();
+}

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/spi/ServiceLoaderHelper.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/spi/ServiceLoaderHelper.java
@@ -1,0 +1,89 @@
+package ai.docling.serve.api.spi;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Utility wrapper around {@code ServiceLoader.load()}.
+ */
+public final class ServiceLoaderHelper {
+    private ServiceLoaderHelper() {
+    }
+
+    /**
+     * Load the first available service of a given type.
+     *
+     * @param clazz the type of service
+     * @param <T>   the type of service
+     * @return the first service, or {@link Optional#empty()} if none
+     */
+    public static <T> Optional<T> loadFactory(Class<T> clazz) {
+        var factories = loadFactories(clazz, null);
+        return factories.isEmpty() ? Optional.empty() : Optional.ofNullable(factories.iterator().next());
+    }
+
+    /**
+     * Load all the services of a given type.
+     *
+     * @param clazz the type of service
+     * @param <T>   the type of service
+     * @return the list of services, empty if none
+     */
+    public static <T> Collection<T> loadFactories(Class<T> clazz) {
+        return loadFactories(clazz, null);
+    }
+
+    /**
+     * Load all the services of a given type.
+     *
+     * <p>Utility mechanism around {@code ServiceLoader.load()}</p>
+     *
+     * <ul>
+     *     <li>If classloader is {@code null}, will try {@code ServiceLoader.load(clazz)}</li>
+     *     <li>If classloader is not {@code null}, will try {@code ServiceLoader.load(clazz, classloader)}</li>
+     *     </ul>
+     *
+     * <p>If the above return nothing, will fall back to {@code ServiceLoader.load(clazz, $this class loader$)}</p>
+     *
+     * @param clazz       the type of service
+     * @param classLoader the classloader to use, may be null
+     * @param <T>         the type of service
+     * @return the list of services, empty if none
+     */
+    public static <T> Collection<T> loadFactories(Class<T> clazz, @Nullable ClassLoader classLoader) {
+      var factories = Optional.ofNullable(classLoader)
+          .map(cl -> loadAll(ServiceLoader.load(clazz, cl)))
+          .orElseGet(() -> loadAll(ServiceLoader.load(clazz)));
+
+      // By default, ServiceLoader.load uses the TCCL, this may not be enough in environment dealing with
+      // classloaders differently such as OSGi. So we should try to use the classloader having loaded this
+      // class. In OSGi it would be the bundle exposing vert.x and so have access to all its classes.
+      var factoriesToReturn =  factories.isEmpty() ?
+          loadAll(ServiceLoader.load(clazz, ServiceLoaderHelper.class.getClassLoader())) :
+          factories;
+
+      return factoriesToReturn.stream()
+          .filter(Objects::nonNull)
+          .toList();
+    }
+
+    /**
+     * Load all the services from a ServiceLoader.
+     *
+     * @param loader the loader
+     * @param <T>    the type of service
+     * @return the list of services, empty if none
+     */
+    private static <T> List<T> loadAll(ServiceLoader<T> loader) {
+        List<T> list = new ArrayList<>();
+        loader.iterator().forEachRemaining(list::add);
+
+        return list;
+    }
+}

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/spi/package-info.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/spi/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package ai.docling.serve.api.spi;
+
+import org.jspecify.annotations.NullMarked;

--- a/docling-serve/docling-serve-api/src/main/java/module-info.java
+++ b/docling-serve/docling-serve-api/src/main/java/module-info.java
@@ -39,4 +39,8 @@ open module ai.docling.serve.api {
 
   // Validation API
   exports ai.docling.serve.api.validation;
+
+  // SPI
+  exports ai.docling.serve.api.spi;
+  uses ai.docling.serve.api.spi.DoclingServeApiBuilderFactory;
 }

--- a/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/DoclingServeApiTests.java
+++ b/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/DoclingServeApiTests.java
@@ -1,0 +1,17 @@
+package ai.docling.serve.api;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.Test;
+
+import ai.docling.serve.api.DoclingServeApi.DoclingApiBuilder;
+import ai.docling.serve.api.spi.DoclingServeApiBuilderFactory;
+
+class DoclingServeApiTests {
+  @Test
+  void noFactoryFound() {
+    assertThatExceptionOfType(IllegalStateException.class)
+        .isThrownBy(() -> DoclingServeApi.builder())
+        .withMessage("No instance of %s found to build a %s instance. You are probably missing a library on your classpath.", DoclingServeApiBuilderFactory.class.getName(), DoclingApiBuilder.class.getName());
+  }
+}

--- a/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/DoclingServeClient.java
+++ b/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/DoclingServeClient.java
@@ -1,6 +1,5 @@
 package ai.docling.serve.client;
 
-import static ai.docling.serve.api.util.ValidationUtils.ensureNotBlank;
 import static ai.docling.serve.api.util.ValidationUtils.ensureNotNull;
 
 import java.io.IOException;
@@ -402,27 +401,13 @@ public abstract class DoclingServeClient extends HttpOperations implements Docli
      * Sets the base URL for the client.
      *
      * <p>This method configures the base URL that will be used for all API requests
-     * executed by the client. The provided URL must be non-null and not blank.
-     *
-     * @param baseUrl the base URL to use, as a {@code String}
-     * @return this builder instance for method chaining
-     * @throws IllegalArgumentException if {@code baseUrl} is null, blank, or invalid
-     */
-    public B baseUrl(String baseUrl) {
-      this.baseUrl = URI.create(ensureNotBlank(baseUrl, "baseUrl"));
-      return (B) this;
-    }
-
-    /**
-     * Sets the base URL for the client.
-     *
-     * <p>This method configures the base URL that will be used for all API requests
      * executed by the client. The provided URL must be non-null.
      *
      * @param baseUrl the base URL to use, as a {@link URI}
      * @return this builder instance for method chaining
      * @throws IllegalArgumentException if {@code baseUrl} is null
      */
+    @Override
     public B baseUrl(URI baseUrl) {
       this.baseUrl = baseUrl;
       return (B) this;

--- a/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/DoclingServeClientBuilderFactory.java
+++ b/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/DoclingServeClientBuilderFactory.java
@@ -1,5 +1,8 @@
 package ai.docling.serve.client;
 
+import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.DoclingServeApi.DoclingApiBuilder;
+import ai.docling.serve.api.spi.DoclingServeApiBuilderFactory;
 import ai.docling.serve.client.DoclingServeClient.DoclingServeClientBuilder;
 
 /**
@@ -15,10 +18,7 @@ import ai.docling.serve.client.DoclingServeClient.DoclingServeClientBuilder;
  * <p>The factory uses a type-safe generic method to support custom subclasses of
  * {@link DoclingServeClient} and {@link DoclingServeClientBuilder}.
  */
-public final class DoclingServeClientBuilderFactory {
-  private DoclingServeClientBuilderFactory() {
-  }
-
+public final class DoclingServeClientBuilderFactory implements DoclingServeApiBuilderFactory {
   /**
    * Creates and returns a new instance of a {@link DoclingServeClientBuilder} compatible
    * with the Jackson version present on the provided classloader's classpath.
@@ -68,6 +68,11 @@ public final class DoclingServeClientBuilderFactory {
    */
   public static <C extends DoclingServeClient, B extends DoclingServeClientBuilder<C, B>> B newBuilder() {
     return newBuilder(Thread.currentThread().getContextClassLoader());
+  }
+
+  @Override
+  public <T extends DoclingServeApi, B extends DoclingApiBuilder<T, B>> B getBuilder() {
+    return (B) newBuilder();
   }
 
   private enum JacksonVersion {

--- a/docling-serve/docling-serve-client/src/main/java/module-info.java
+++ b/docling-serve/docling-serve-client/src/main/java/module-info.java
@@ -9,4 +9,5 @@ module ai.docling.serve.client {
   requires java.net.http;
 
   exports ai.docling.serve.client;
+  provides ai.docling.serve.api.spi.DoclingServeApiBuilderFactory with ai.docling.serve.client.DoclingServeClientBuilderFactory;
 }

--- a/docling-serve/docling-serve-client/src/main/resources/META-INF/services/ai.docling.serve.api.spi.DoclingServeApiBuilderFactory
+++ b/docling-serve/docling-serve-client/src/main/resources/META-INF/services/ai.docling.serve.api.spi.DoclingServeApiBuilderFactory
@@ -1,0 +1,1 @@
+ai.docling.serve.client.DoclingServeClientBuilderFactory

--- a/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/AbstractDoclingServeClientTests.java
+++ b/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/AbstractDoclingServeClientTests.java
@@ -62,6 +62,7 @@ import ai.docling.serve.api.validation.ValidationError;
 import ai.docling.serve.api.validation.ValidationErrorContext;
 import ai.docling.serve.api.validation.ValidationErrorDetail;
 import ai.docling.serve.api.validation.ValidationException;
+import ai.docling.serve.client.DoclingServeClient.DoclingServeClientBuilder;
 import ai.docling.testcontainers.serve.DoclingServeContainer;
 import ai.docling.testcontainers.serve.config.DoclingServeContainerConfig;
 
@@ -111,6 +112,23 @@ abstract class AbstractDoclingServeClientTests {
 
   private <T> String writeValueAsString(T value) {
     return ((DoclingServeClient) getDoclingClient()).writeValueAsString(value);
+  }
+
+  @Test
+  void builderWorks() {
+    var clientBuilder = DoclingServeApi.builder()
+        .logRequests()
+        .logResponses()
+        .prettyPrint()
+        .baseUrl(doclingContainer.getApiUrl());
+
+    assertThat(clientBuilder)
+        .isNotNull()
+        .isInstanceOf(DoclingServeClientBuilder.class);
+
+    assertThat(clientBuilder.build())
+        .isNotNull()
+        .isInstanceOf(DoclingServeClient.class);
   }
 
   @Nested

--- a/docs/src/doc/docs/docling-serve/serve-api.md
+++ b/docs/src/doc/docs/docling-serve/serve-api.md
@@ -60,11 +60,12 @@ import ai.docling.serve.api.convert.request.options.OutputFormat;
 import ai.docling.serve.api.convert.request.source.HttpSource;
 import ai.docling.serve.api.convert.request.target.InBodyTarget;
 import ai.docling.serve.api.convert.response.ConvertDocumentResponse;
-import ai.docling.serve.client.DoclingServeClientBuilderFactory; // from docling-serve-client
 
-DoclingServeApi api = DoclingServeClientBuilderFactory
-    .newBuilder()
+DoclingServeApi api = DoclingServeApi.builder()
     .baseUrl("http://localhost:8000") // your Docling Serve URL
+    .logRequests() // log HTTP requests
+    .logResponses() // log HTTP responses
+    .prettyPrint() // pretty-print JSON requests/responses
     .build();
 
 ConvertDocumentRequest request = ConvertDocumentRequest.builder()
@@ -89,6 +90,12 @@ Defined in `ai.docling.serve.api.DoclingServeApi`, this interface exposes many o
 
 Any HTTP or non-HTTP implementation can implement this interface. The reference implementation is
 provided by the `docling-serve-client` module.
+
+### Extension Points
+
+The `docling-serve-api` module uses the [Java Service Provider Interface](https://www.baeldung.com/java-spi) to define an extension point for building/customizing instances of `DoclingServeApi`. An application (or downstream framework) can create an implementation of `ai.docling.serve.api.spi.DoclingServeApiBuilderFactory` and register it via the `META-INF/services/ai.docling.serve.api.spi.DoclingServeApiBuilderFactory` file, or providing an implementation using Java modules.
+
+This is exactly what the `docling-serve-client` module does to provide its implementation. See [`module-info.java`](https://github.com/docling-project/docling-java/blob/main/docling-serve/docling-serve-client/src/main/java/module-info.java) and [`DoclingServeClientBuilderFactory.java`](https://github.com/docling-project/docling-java/blob/main/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/DoclingServeClientBuilderFactory.java).
 
 ### Requests: `ConvertDocumentRequest`
 

--- a/docs/src/doc/docs/docling-serve/serve-client.md
+++ b/docs/src/doc/docs/docling-serve/serve-client.md
@@ -49,7 +49,7 @@ This artifact brings in the API types transitively, so you can use `DoclingServe
 
 ## Quick start
 
-Create a client with `DoclingServeClientBuilderFactory`, build a request, and call `convertSource()`:
+Create a client with `DoclingServeApi.builder()`, build a request, and call `convertSource()`:
 
 ```java
 import java.net.URI;
@@ -60,11 +60,12 @@ import ai.docling.serve.api.convert.request.options.OutputFormat;
 import ai.docling.serve.api.convert.request.source.HttpSource;
 import ai.docling.serve.api.convert.request.target.InBodyTarget;
 import ai.docling.serve.api.convert.response.ConvertDocumentResponse;
-import ai.docling.serve.client.DoclingServeClientBuilderFactory;
 
-DoclingServeApi api = DoclingServeClientBuilderFactory
-    .newBuilder()
+DoclingServeApi api = DoclingServeApi.builder()
     .baseUrl("http://localhost:8000") // your Docling Serve URL
+    .logRequests() // log HTTP requests
+    .logResponses() // log HTTP responses
+    .prettyPrint() // pretty-print JSON requests/responses
     .build();
 
 ConvertDocumentRequest request = ConvertDocumentRequest.builder()
@@ -84,8 +85,7 @@ System.out.println(response.getDocument().getMarkdownContent());
 
 ### Builder factory and Jackson auto‑detection
 
-`DoclingServeClientBuilderFactory.newBuilder()` chooses an implementation based on what's on
-your classpath:
+`DoclingServeApi.builder()` chooses an implementation based on what's on your classpath:
 
 - Jackson 3 present → `DoclingServeJackson3Client`
 - Else if Jackson 2 present → `DoclingServeJackson2Client`
@@ -99,7 +99,7 @@ client type if you need special Jackson modules or settings.
 Set the Docling Serve base URL with either a `String` or `URI`:
 
 ```java
-DoclingServeApi api = DoclingServeClientBuilderFactory.newBuilder()
+DoclingServeApi api = DoclingServeApi.builder()
     .baseUrl("http://localhost:8000")
     .build();
 ```
@@ -115,7 +115,7 @@ You can supply and tune a `java.net.http.HttpClient.Builder`:
 import java.net.http.HttpClient;
 import java.time.Duration;
 
-DoclingServeApi api = DoclingServeClientBuilderFactory.newBuilder()
+DoclingServeApi api = DoclingServeApi.builder()
     .baseUrl("https://serve.example.com")
     .httpClientBuilder(HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(20))


### PR DESCRIPTION
- Added SPI-based extension points for `DoclingServeApi` using `DoclingServeApiBuilderFactory`.
- Replaced `DoclingServeClientBuilderFactory` with a unified `DoclingServeApi.builder()` factory method.
- Updated API and client layers to align with the new builder factory model.
- Simplified documentation and examples to reflect the updated API usage.
- Enhanced test coverage for SPI-based customization and factory functionality.