### PR TITLE
fix: string.isBlank() is equivalent to string.trim().isBlank()

### DIFF
--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/util/Utils.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/util/Utils.java
@@ -93,7 +93,7 @@ public final class Utils {
      * @return true if the string is {@code null} or blank.
      */
     public static boolean isNullOrBlank(String string) {
-        return string == null || string.trim().isBlank();
+        return string == null || string.isBlank();
     }
 
     /**


### PR DESCRIPTION
isBlank() already handles whitespace-only strings directly without creating an intermediate object (starting from Java 11+). The trim() call was redundant - it would only matter if we cared about the trimmed result, but we're just checking blankness.