### PR TITLE
fix(serve): Incorrect values in OcrEngine enum

### DIFF
--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/convert/request/options/OcrEngine.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/convert/request/options/OcrEngine.java
@@ -7,10 +7,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public enum OcrEngine {
 
+  @JsonProperty("auto") AUTO,
   @JsonProperty("easyocr") EASYOCR,
-  @JsonProperty("mac") OCRMAC,
+  @JsonProperty("ocrmac") OCRMAC,
   @JsonProperty("rapidocr") RAPIDOCR,
-  @JsonProperty("tesseract") TESSEROCR,
-  @JsonProperty("tesseract_cloud") TESSERACT
+  @JsonProperty("tesserocr") TESSEROCR,
+  @JsonProperty("tesseract") TESSERACT
 
 }


### PR DESCRIPTION
Ensure all values in the OcrEngine enum are correct, based on the Docling Serve API spec.