### PR TITLE
feat: Support configuring timeouts in DoclingServeApi.Builder

### DIFF
--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/DoclingServeApi.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/DoclingServeApi.java
@@ -169,6 +169,16 @@ public interface DoclingServeApi
     }
 
     /**
+     * Timeout to establish a connection to the Docling Serve API.
+     */
+    B connectTimeout(Duration connectTimeout);
+
+    /**
+     * Timeout for receiving a response from the Docling Serve API.
+     */
+    B readTimeout(Duration readTimeout);
+
+    /**
      * Sets the polling interval for async operations.
      *
      * <p>This configures how frequently the client will check the status of async

--- a/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/util/ValidationUtils.java
+++ b/docling-serve/docling-serve-api/src/main/java/ai/docling/serve/api/util/ValidationUtils.java
@@ -3,9 +3,12 @@ package ai.docling.serve.api.util;
 import static ai.docling.serve.api.util.Utils.isNullOrBlank;
 import static ai.docling.serve.api.util.Utils.isNullOrEmpty;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * Utility class for validating method arguments.
@@ -271,4 +274,16 @@ public final class ValidationUtils {
         }
         return i;
     }
+
+  /**
+   * Ensures that the given duration is positive.
+   * @param duration The duration to check.
+   * @throws IllegalArgumentException if the duration is negative or zero.
+   */
+  public static void ensurePositiveDuration(@Nullable Duration duration, String name) {
+      if (duration == null || duration.isNegative() || duration.isZero()) {
+        throw new IllegalArgumentException("%s must be a positive duration".formatted(name));
+      }
+    }
+
 }

--- a/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/util/ValidationUtilsTests.java
+++ b/docling-serve/docling-serve-api/src/test/java/ai/docling/serve/api/util/ValidationUtilsTests.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -261,4 +262,16 @@ class ValidationUtilsTests {
                     .withMessageContaining("test must be between 0 and 1, but is: -1");
         }
     }
+
+    @Test
+    void ensurePositiveDuration() {
+      ValidationUtils.ensurePositiveDuration(Duration.ofSeconds(1), "test");
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(() -> ValidationUtils.ensurePositiveDuration(Duration.ofSeconds(-1), "test"))
+          .withMessageContaining("test must be a positive duration");
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(() -> ValidationUtils.ensurePositiveDuration(Duration.ofSeconds(0), "test"))
+          .withMessageContaining("test must be a positive duration");
+    }
+
 }

--- a/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/AbstractDoclingServeClientTests.java
+++ b/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/AbstractDoclingServeClientTests.java
@@ -177,6 +177,8 @@ abstract class AbstractDoclingServeClientTests {
         .logResponses()
         .prettyPrint()
         .baseUrl(baseUrl)
+        .connectTimeout(Duration.ofSeconds(10))
+        .readTimeout(Duration.ofSeconds(45))
         .build();
 
     assertThat(client.health())


### PR DESCRIPTION
Add support for connect and read timeout in DoclingServeApi.Builder and implement the new fields in the reference client implementation.