### PR TITLE
feat(version-tests): Add comprehensive API coverage to TagsTester

### DIFF
--- a/docling-testing/docling-version-tests/src/main/java/ai/docling/client/tester/service/TagsTester.java
+++ b/docling-testing/docling-version-tests/src/main/java/ai/docling/client/tester/service/TagsTester.java
@@ -19,13 +19,17 @@ import ai.docling.client.tester.domain.TagsTestRequest;
 import ai.docling.client.tester.domain.TagsTestResults;
 import ai.docling.core.DoclingDocument;
 import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.clear.request.ClearConvertersRequest;
+import ai.docling.serve.api.clear.request.ClearResultsRequest;
 import ai.docling.serve.api.convert.request.ConvertDocumentRequest;
 import ai.docling.serve.api.convert.request.options.ConvertDocumentOptions;
 import ai.docling.serve.api.convert.request.options.OutputFormat;
+import ai.docling.serve.api.convert.request.options.TableFormerMode;
 import ai.docling.serve.api.convert.request.source.HttpSource;
 import ai.docling.serve.api.convert.response.ConvertDocumentResponse;
 import ai.docling.serve.api.convert.response.DocumentResponse;
 import ai.docling.serve.api.convert.response.InBodyConvertDocumentResponse;
+import ai.docling.serve.api.convert.response.ResponseType;
 import ai.docling.serve.api.health.HealthCheckResponse;
 import ai.docling.testcontainers.serve.DoclingServeContainer;
 import ai.docling.testcontainers.serve.config.DoclingServeContainerConfig;
@@ -146,7 +150,7 @@ public class TagsTester {
     
     assertThat(response.getResponseType())
         .as("Response type should be IN_BODY")
-        .isEqualTo(ai.docling.serve.api.convert.response.ResponseType.IN_BODY);
+        .isEqualTo(ResponseType.IN_BODY);
     
     var inBodyResponse = (InBodyConvertDocumentResponse)response;
     
@@ -172,7 +176,7 @@ public class TagsTester {
     var options = ConvertDocumentOptions.builder()
         .doOcr(true)
         .includeImages(true)
-        .tableMode(ai.docling.serve.api.convert.request.options.TableFormerMode.FAST)
+        .tableMode(TableFormerMode.FAST)
         .documentTimeout(Duration.ofMinutes(1))
         .build();
 
@@ -189,7 +193,7 @@ public class TagsTester {
     
     assertThat(response.getResponseType())
         .as("Response type should be IN_BODY")
-        .isEqualTo(ai.docling.serve.api.convert.response.ResponseType.IN_BODY);
+        .isEqualTo(ResponseType.IN_BODY);
     
     var inBodyResponse = (InBodyConvertDocumentResponse)response;
     
@@ -203,7 +207,7 @@ public class TagsTester {
   }
   
   private void testClearConverters(DoclingServeApi doclingClient) {
-    var request = ai.docling.serve.api.clear.request.ClearConvertersRequest.builder().build();
+    var request = ClearConvertersRequest.builder().build();
     var response = doclingClient.clearConverters(request);
     
     assertThat(response)
@@ -216,7 +220,7 @@ public class TagsTester {
   }
   
   private void testClearResults(DoclingServeApi doclingClient) {
-    var request = ai.docling.serve.api.clear.request.ClearResultsRequest.builder().build();
+    var request = ClearResultsRequest.builder().build();
     var response = doclingClient.clearResults(request);
     
     assertThat(response)

--- a/docling-testing/docling-version-tests/src/main/java/ai/docling/client/tester/service/TagsTester.java
+++ b/docling-testing/docling-version-tests/src/main/java/ai/docling/client/tester/service/TagsTester.java
@@ -96,6 +96,24 @@ public class TagsTester {
         .build();
 
     checkDoclingHealthy(doclingClient);
+    
+    // Convert with multiple output formats
+    testConvertWithMultipleFormats(doclingClient);
+    
+    // Convert with JSON format and validate DoclingDocument
+    testConvertWithJsonFormat(doclingClient);
+    
+    // Convert with different document options
+    testConvertWithDifferentOptions(doclingClient);
+    
+    // Clear converters
+    testClearConverters(doclingClient);
+    
+    // Clear results
+    testClearResults(doclingClient);
+  }
+  
+  private void testConvertWithMultipleFormats(DoclingServeApi doclingClient) {
     var options = ConvertDocumentOptions.builder()
         .abortOnError(true)
         .includeImages(true)
@@ -108,6 +126,106 @@ public class TagsTester {
         .build();
 
     checkDoclingResponse(doclingClient.convertSource(request));
+  }
+  
+  private void testConvertWithJsonFormat(DoclingServeApi doclingClient) {
+    var options = ConvertDocumentOptions.builder()
+        .toFormat(OutputFormat.JSON)
+        .build();
+
+    var request = ConvertDocumentRequest.builder()
+        .source(HttpSource.builder().url(URI.create("https://docling.ai")).build())
+        .options(options)
+        .build();
+
+    var response = doclingClient.convertSource(request);
+    
+    assertThat(response)
+        .as("Response should not be null")
+        .isNotNull();
+    
+    assertThat(response.getResponseType())
+        .as("Response type should be IN_BODY")
+        .isEqualTo(ai.docling.serve.api.convert.response.ResponseType.IN_BODY);
+    
+    var inBodyResponse = (InBodyConvertDocumentResponse)response;
+    
+    assertThat(inBodyResponse.getStatus())
+        .as("Response status should not be empty")
+        .isNotEmpty();
+    
+    assertThat(inBodyResponse.getDocument())
+        .as("Response should have a document")
+        .isNotNull();
+    
+    var doclingDocument = inBodyResponse.getDocument().getJsonContent();
+    assertThat(doclingDocument)
+        .as("Document should have JSON content")
+        .isNotNull();
+    
+    assertThat(doclingDocument.getName())
+        .as("Document name should not be empty")
+        .isNotEmpty();
+  }
+  
+  private void testConvertWithDifferentOptions(DoclingServeApi doclingClient) {
+    var options = ConvertDocumentOptions.builder()
+        .doOcr(true)
+        .includeImages(true)
+        .tableMode(ai.docling.serve.api.convert.request.options.TableFormerMode.FAST)
+        .documentTimeout(Duration.ofMinutes(1))
+        .build();
+
+    var request = ConvertDocumentRequest.builder()
+        .source(HttpSource.builder().url(URI.create("https://docling.ai")).build())
+        .options(options)
+        .build();
+
+    var response = doclingClient.convertSource(request);
+    
+    assertThat(response)
+        .as("Response should not be null")
+        .isNotNull();
+    
+    assertThat(response.getResponseType())
+        .as("Response type should be IN_BODY")
+        .isEqualTo(ai.docling.serve.api.convert.response.ResponseType.IN_BODY);
+    
+    var inBodyResponse = (InBodyConvertDocumentResponse)response;
+    
+    assertThat(inBodyResponse.getStatus())
+        .as("Response status should not be empty")
+        .isNotEmpty();
+    
+    assertThat(inBodyResponse.getDocument())
+        .as("Response should have a document")
+        .isNotNull();
+  }
+  
+  private void testClearConverters(DoclingServeApi doclingClient) {
+    var request = ai.docling.serve.api.clear.request.ClearConvertersRequest.builder().build();
+    var response = doclingClient.clearConverters(request);
+    
+    assertThat(response)
+        .as("Clear converters response should not be null")
+        .isNotNull();
+    
+    assertThat(response.getStatus())
+        .as("Clear converters status should be 'ok'")
+        .isEqualTo("ok");
+  }
+  
+  private void testClearResults(DoclingServeApi doclingClient) {
+    var request = ai.docling.serve.api.clear.request.ClearResultsRequest.builder().build();
+    var response = doclingClient.clearResults(request);
+    
+    assertThat(response)
+        .as("Clear results response should not be null")
+        .isNotNull();
+    
+    assertThat(response.getStatus())
+        .as("Clear results status should be 'ok'")
+        .isEqualTo("ok");
   }
 
   private void checkDoclingResponse(ConvertDocumentResponse response) {


### PR DESCRIPTION
## Description
Expanded the version compatibility tests in `TagsTester.java` to include comprehensive API coverage beyond just the convert source endpoint, as requested in #134.

## Changes Made
Added 5 new test methods to `doConversion()` in `TagsTester.java`:

1. **testConvertWithMultipleFormats** - Tests conversion with MARKDOWN, JSON, and TEXT output formats ( already existed, done only refactoring)

2. **testConvertWithJsonFormat** - Validates JSON output and DoclingDocument deserialization
- Requests only JSON format
- Tests: "Can we properly deserialize the JSON into a DoclingDocument Java object?"
- Validates: The JSON structure is correct and can be parsed into the Java class
- Checks: Specific fields like getName() work correctly

3. **testConvertWithDifferentOptions** - Tests conversion with OCR, images, table mode, and custom timeout
- Extracts text from images in the document 
- Embeds or references images in the converted output
- Controls how tables are extracted and formatted
- Sets maximum time for document processing

4. **testClearConverters** - Tests the `/v1/clear/converters` endpoint
- Clears cached converter instances (PDF parsers, OCR engines, etc.)

5. **testClearResults** - Tests the `/v1/clear/results` endpoint
- Clears cached conversion results (the actual converted documents)

## Motivation
The previous implementation only tested the basic convert source API. This enhancement provides:
- Better coverage of the Docling Serve API surface
- Validation of multiple endpoints (health, convert, clear)
- Testing of various conversion options and output formats
- More comprehensive compatibility checks across versions

## Test Results
- [x] Build successful with no compilation errors
- [x] All v1.x versions (v1.0.0+) pass all 6 tests
- [ ] v0.x versions fail as expected (AP
[results.md](https://github.com/user-attachments/files/26478352/results.md)