### PR TITLE
feat: improve error message when Jackson is missing from classpath

### DIFF
--- a/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/DoclingServeClientBuilderFactory.java
+++ b/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/DoclingServeClientBuilderFactory.java
@@ -55,7 +55,7 @@ public final class DoclingServeClientBuilderFactory implements DoclingServeApiBu
 
         For Jackson 3:
           Maven:  tools.jackson.core:jackson-databind
-          Gradle: implementation("tools.jackson.core:jackson-databind:$version")\
+          Gradle: implementation("tools.jackson.core:jackson-databind:$version")
         """);
   }
 

--- a/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/DoclingServeClientBuilderFactory.java
+++ b/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/DoclingServeClientBuilderFactory.java
@@ -51,11 +51,11 @@ public final class DoclingServeClientBuilderFactory implements DoclingServeApiBu
 
         For Jackson 2:
           Maven:  com.fasterxml.jackson.core:jackson-databind
-          Gradle: implementation("com.fasterxml.jackson.core:jackson-databind:$version")
+          Gradle: implementation("com.fasterxml.jackson.core:jackson-databind:<version>")
 
         For Jackson 3:
           Maven:  tools.jackson.core:jackson-databind
-          Gradle: implementation("tools.jackson.core:jackson-databind:$version")
+          Gradle: implementation("tools.jackson.core:jackson-databind:<version>")
         """);
   }
 

--- a/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/DoclingServeClientBuilderFactory.java
+++ b/docling-serve/docling-serve-client/src/main/java/ai/docling/serve/client/DoclingServeClientBuilderFactory.java
@@ -46,7 +46,17 @@ public final class DoclingServeClientBuilderFactory implements DoclingServeApiBu
       return (B) DoclingServeJackson2Client.builder();
     }
 
-    throw new IllegalStateException("Neither Jackson 2 or 3 is on the classpath");
+    throw new IllegalStateException("""
+        Neither Jackson 2 nor Jackson 3 is on the classpath. You must add one of the following dependencies:
+
+        For Jackson 2:
+          Maven:  com.fasterxml.jackson.core:jackson-databind
+          Gradle: implementation("com.fasterxml.jackson.core:jackson-databind:$version")
+
+        For Jackson 3:
+          Maven:  tools.jackson.core:jackson-databind
+          Gradle: implementation("tools.jackson.core:jackson-databind:$version")\
+        """);
   }
 
   /**

--- a/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/DoclingServeClientBuilderFactoryTests.java
+++ b/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/DoclingServeClientBuilderFactoryTests.java
@@ -28,7 +28,9 @@ class DoclingServeClientBuilderFactoryTests {
 
     assertThatExceptionOfType(IllegalStateException.class)
         .isThrownBy(() -> DoclingServeClientBuilderFactory.<DoclingServeClient, DoclingServeClientBuilder>newBuilder(classLoader))
-        .withMessage("Neither Jackson 2 or 3 is on the classpath");
+        .withMessageContaining("Neither Jackson 2 nor Jackson 3 is on the classpath")
+        .withMessageContaining("com.fasterxml.jackson.core:jackson-databind")
+        .withMessageContaining("tools.jackson.core:jackson-databind");
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Summary
- Improves the `IllegalStateException` message thrown when neither Jackson 2 nor Jackson 3 is on the classpath to include actionable Maven/Gradle dependency coordinates
- Updates the corresponding test assertion to verify the new message content

## Test plan
- [x] `DoclingServeClientBuilderFactoryTests.noBuilderWhenNeitherArePresent()` passes with updated assertion
- [x] All other `DoclingServeClientBuilderFactoryTests` remain green
- [x] `spotlessCheck` passes

Closes #470