### PR TITLE
feat: add Maven BOM module for aligned dependency management

### DIFF
--- a/buildSrc/src/main/kotlin/docling-release.gradle.kts
+++ b/buildSrc/src/main/kotlin/docling-release.gradle.kts
@@ -1,6 +1,11 @@
 plugins {
-  id("docling-sbom")
   `maven-publish`
+}
+
+val isJavaPlatform = pluginManager.hasPlugin("java-platform")
+
+if (!isJavaPlatform) {
+  apply(plugin = "docling-sbom")
 }
 
 publishing {
@@ -12,18 +17,22 @@ publishing {
 
   publications {
     create<MavenPublication>("maven") {
-      from(components["java"])
-
-      // Attach SBOM artifacts to publication
-      val cyclonedxTask = tasks.named<org.cyclonedx.gradle.CyclonedxDirectTask>("cyclonedxDirectBom").get()
-      artifact(cyclonedxTask.jsonOutput) {
-        classifier = "cyclonedx"
-        extension = "json"
+      if (isJavaPlatform) {
+        from(components["javaPlatform"])
       }
+      else {
+        from(components["java"])
 
-      artifact(cyclonedxTask.xmlOutput) {
-        classifier = "cyclonedx"
-        extension = "xml"
+        val cyclonedxTask = tasks.named<org.cyclonedx.gradle.CyclonedxDirectTask>("cyclonedxDirectBom").get()
+        artifact(cyclonedxTask.jsonOutput) {
+          classifier = "cyclonedx"
+          extension = "json"
+        }
+
+        artifact(cyclonedxTask.xmlOutput) {
+          classifier = "cyclonedx"
+          extension = "xml"
+        }
       }
 
       pom {

--- a/docling-bom/build.gradle.kts
+++ b/docling-bom/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+  `java-platform`
+  id("docling-shared")
+  id("docling-release")
+}
+
+description = "Docling Java BOM"
+
+dependencies {
+  constraints {
+    api(project(":docling-core"))
+    api(project(":docling-serve-api"))
+    api(project(":docling-serve-client"))
+    api(project(":docling-testcontainers"))
+  }
+}

--- a/docs/src/doc/docs/whats-new.md
+++ b/docs/src/doc/docs/whats-new.md
@@ -2,9 +2,27 @@
 
 Docling Java {{ gradle.project_version }} includes important breaking changes, along with new features, enhancements, and bug fixes. This page includes the highlights of the release, but you can also check out the full [release notes](https://github.com/docling-project/docling-java/releases) for more details about each change.
 
+## General
+
+### {{ gradle.project_version }}
+
+* **New `docling-bom` module** — A Maven BOM (`ai.docling:docling-bom`) is now published, allowing consumers to align all Docling Java module versions with a single import.
+
+### 0.5.1
+
+* Include `furniture` field in `DoclingDocument`.
+* CycloneDX SBOM artifacts are now published alongside each module.
+
+### 0.1.5
+
+* New `docling-core` module with `DoclingDocument` API mirroring the [docling-core](https://github.com/docling-project/docling-core) Python library's document representation model.
+
 ## Docling Serve
 
 ### {{ gradle.project_version }}
+
+
+### 0.5.0
 
 #### Breaking Changes
 
@@ -26,10 +44,25 @@ Docling Java {{ gradle.project_version }} includes important breaking changes, a
         * Target is `S3Target` or `PutTarget`
 * **Migration guide:** Use `getResponseType()` to determine the concrete type and cast accordingly, or use pattern matching (Java 16+) or instanceof checks to handle different response types.
 
-### 0.4.8
+### 0.4.7
+
+* Support configuring timeouts in `DoclingServeApi.Builder` via `connectTimeout(Duration)` and `requestTimeout(Duration)`.
+* Fix incorrect values in `OcrEngine` enum.
+
+### 0.4.4
+
+* Fix: path component in `baseUrl` is now correctly preserved when building API request URIs.
+
+### 0.4.3
 
 * Add S3-based source and target support with enhanced extensibility.
 * Introduce API extension point and enhance builder usage.
+
+### 0.4.2
+
+* Migrate from `java.util.logging` to SLF4J for logging.
+* Fix custom `Duration` serializers with `ChronoUnit` support.
+* Fix JSON property name from `options` to `convert_options` in chunk document requests.
 
 ### 0.4.1
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 rootProject.name = "docling-java"
-include("docling-core", "docling-serve-api", "docling-serve-client", "docs", "docling-testcontainers", "docling-version-tests", "test-report-aggregation")
+include("docling-bom", "docling-core", "docling-serve-api", "docling-serve-client", "docs", "docling-testcontainers", "docling-version-tests", "test-report-aggregation")
 
 project(":docling-serve-api").projectDir = file("docling-serve/docling-serve-api")
 project(":docling-serve-client").projectDir = file("docling-serve/docling-serve-client")


### PR DESCRIPTION
## Summary

- Add a `docling-bom` module (`ai.docling:docling-bom`) using Gradle's `java-platform` plugin with version constraints for all 4 published modules
- Refactor `docling-release.gradle.kts` to conditionally handle `java-platform` modules (correct component type, skip SBOM generation)
- Update `whats-new.md` with release summaries for previously missing versions (0.5.1, 0.4.7, 0.4.4, 0.4.3, 0.4.2, 0.1.5) and document the new BOM

Closes #481

## Test plan

- [x] `./gradlew --no-daemon :docling-bom:publish` — BOM publishes to staging with correct POM (`<packaging>pom</packaging>`, `<dependencyManagement>` with all 4 modules)
- [x] `./gradlew --no-daemon publish` — full publish works, all 5 artifacts staged
- [x] `./gradlew --no-daemon build` — full build passes
- [x] Existing modules still produce CycloneDX SBOM artifacts
- [x] BOM module does NOT produce SBOM artifacts