### PR TITLE
fix: correct Codecov configuration for full module coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,6 +8,7 @@ coverage:
       default:
         target: auto
         threshold: 1%
+        after_n_builds: 3
         if_not_found: success
       docling-core:
         target: auto
@@ -37,8 +38,21 @@ coverage:
         target: auto
         threshold: 1%
         paths:
-          - "docling/testing/docling-version-tests/src/main/java/**"
+          - "docling-testing/docling-version-tests/src/main/java/**"
         if_not_found: success
+flags:
+  java17:
+    paths:
+      - "!**/test/**"
+    carryforward: true
+  java21:
+    paths:
+      - "!**/test/**"
+    carryforward: true
+  java25:
+    paths:
+      - "!**/test/**"
+    carryforward: true
 comment:
   layout: "header,diff,flags,tree,footer"
   behavior: default
@@ -49,5 +63,3 @@ ignore:
   - "**/test/**"
   - "docs/**"
   - "buildSrc/**"
-  - "docling-testcontainers/**"
-  - "docling-testing/**"

--- a/docs/src/doc/docs/whats-new.md
+++ b/docs/src/doc/docs/whats-new.md
@@ -7,6 +7,7 @@ Docling Java {{ gradle.project_version }} includes important breaking changes, a
 ### {{ gradle.project_version }}
 
 * **New `docling-bom` module** — A Maven BOM (`ai.docling:docling-bom`) is now published, allowing consumers to align all Docling Java module versions with a single import.
+* **Codecov configuration fixes** — Fixed module path mappings, ignore rules, and added per-Java-version coverage flags for accurate coverage reporting across all modules.
 
 ### 0.5.1
 


### PR DESCRIPTION
## Summary
- Fix wrong path for `docling-version-tests` project status (`docling/testing/...` → `docling-testing/...`) which prevented Codecov from mapping coverage to this module
- Remove overly broad `ignore` rules that excluded `docling-testcontainers/**` and `docling-testing/**` from all coverage analysis, conflicting with their project status entries
- Add `after_n_builds: 3` so Codecov waits for all 3 Java version uploads before computing coverage, preventing fluctuating coverage numbers across commits
- Define `java17`/`java21`/`java25` flags with `carryforward: true` for per-Java-version coverage tracking on the dashboard and in PR comments

## Test plan
- [ ] Verify CI passes and all 3 `prepare-test-reports` jobs upload coverage successfully
- [ ] Check Codecov dashboard shows all 5 modules: `docling-core`, `docling-serve-api`, `docling-serve-client`, `docling-testcontainers`, `docling-version-tests`
- [ ] Verify PR comment includes per-flag (java17/java21/java25) coverage breakdown
- [ ] Confirm the "error processing coverage reports" message no longer appears
- [ ] Monitor subsequent commits to verify coverage no longer fluctuates