### PR TITLE
chore: update CycloneDX plugin to v3.3.0 and refactor publication setup

### DIFF
--- a/buildSrc/src/main/kotlin/docling-java-shared.gradle.kts
+++ b/buildSrc/src/main/kotlin/docling-java-shared.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 
 testing {
   suites {
-    val test by getting(JvmTestSuite::class) {
+    getByName<JvmTestSuite>("test") {
       useJUnitJupiter()
     }
   }

--- a/buildSrc/src/main/kotlin/docling-java-shared.gradle.kts
+++ b/buildSrc/src/main/kotlin/docling-java-shared.gradle.kts
@@ -31,10 +31,8 @@ dependencies {
 }
 
 testing {
-  suites {
-    getByName<JvmTestSuite>("test") {
-      useJUnitJupiter()
-    }
+  suites.withType<JvmTestSuite> {
+    useJUnitJupiter()
   }
 }
 

--- a/buildSrc/src/main/kotlin/docling-release.gradle.kts
+++ b/buildSrc/src/main/kotlin/docling-release.gradle.kts
@@ -30,10 +30,11 @@ publishing {
           extension = "json"
         }
 
-        artifact(cyclonedxTask.flatMap { it.xmlOutput }) {
-          classifier = "cyclonedx"
-          extension = "xml"
-        }
+artifact(cyclonedxTask.flatMap { it.xmlOutput }) {
+  classifier = "cyclonedx"
+  extension = "xml"
+  builtBy(cyclonedxTask)
+}
       }
 
       pom {

--- a/buildSrc/src/main/kotlin/docling-release.gradle.kts
+++ b/buildSrc/src/main/kotlin/docling-release.gradle.kts
@@ -19,7 +19,8 @@ publishing {
     create<MavenPublication>("maven") {
       if (isJavaPlatform) {
         from(components["javaPlatform"])
-      } else {
+      }
+      else {
         from(components["java"])
 
         // Attach SBOM artifacts to publication
@@ -33,43 +34,43 @@ publishing {
           classifier = "cyclonedx"
           extension = "xml"
         }
+      }
 
-        pom {
-          url = "https://docling-project.github.io/docling-java"
-          name = project.name
-          description.set(provider { project.description })
-          licenses {
-            license {
-              name = "MIT License"
-              url = "https://opensource.org/license/mit"
-            }
+      pom {
+        url = "https://docling-project.github.io/docling-java"
+        name = project.name
+        description.set(provider { project.description })
+        licenses {
+          license {
+            name = "MIT License"
+            url = "https://opensource.org/license/mit"
           }
-          properties = project.extra.properties.entries.associate { (k, v) -> k to v.toString() }
-          developers {
-            developer {
-              id = "edeandrea"
-              name = "Eric Deandrea"
-              email = "eric.deandrea@ibm.com"
-              organization = "IBM"
-            }
-            developer {
-              id = "ThomasVitale"
-              name = "Thomas Vitale"
-              url = "https://thomasvitale.com"
-            }
-            developer {
-              id = "lordofthejars"
-              name = "Alex Soto"
-              email = "asotobu@gmail.com"
-              url = "https://www.lordofthejars.com"
-              organization = "IBM"
-            }
+        }
+        properties = project.extra.properties.entries.associate { (k, v) -> k to v.toString() }
+        developers {
+          developer {
+            id = "edeandrea"
+            name = "Eric Deandrea"
+            email = "eric.deandrea@ibm.com"
+            organization = "IBM"
           }
-          scm {
-            connection = "scm:git:git://github.com/docling-project/docling-java.git"
-            developerConnection = "scm:git:ssh://github.com:docling-project/docling-java.git"
-            url = "https://github.com/docling-project/docling-java"
+          developer {
+            id = "ThomasVitale"
+            name = "Thomas Vitale"
+            url = "https://thomasvitale.com"
           }
+          developer {
+            id = "lordofthejars"
+            name = "Alex Soto"
+            email = "asotobu@gmail.com"
+            url = "https://www.lordofthejars.com"
+            organization = "IBM"
+          }
+        }
+        scm {
+          connection = "scm:git:git://github.com/docling-project/docling-java.git"
+          developerConnection = "scm:git:ssh://github.com:docling-project/docling-java.git"
+          url = "https://github.com/docling-project/docling-java"
         }
       }
     }

--- a/buildSrc/src/main/kotlin/docling-release.gradle.kts
+++ b/buildSrc/src/main/kotlin/docling-release.gradle.kts
@@ -19,57 +19,57 @@ publishing {
     create<MavenPublication>("maven") {
       if (isJavaPlatform) {
         from(components["javaPlatform"])
-      }
-      else {
+      } else {
         from(components["java"])
 
-        val cyclonedxTask = tasks.named<org.cyclonedx.gradle.CyclonedxDirectTask>("cyclonedxDirectBom").get()
-        artifact(cyclonedxTask.jsonOutput) {
+        // Attach SBOM artifacts to publication
+        val cyclonedxTask = tasks.named<org.cyclonedx.gradle.CyclonedxDirectTask>("cyclonedxDirectBom")
+        artifact(cyclonedxTask.flatMap { it.jsonOutput }) {
           classifier = "cyclonedx"
           extension = "json"
         }
 
-        artifact(cyclonedxTask.xmlOutput) {
+        artifact(cyclonedxTask.flatMap { it.xmlOutput }) {
           classifier = "cyclonedx"
           extension = "xml"
         }
-      }
 
-      pom {
-        url = "https://docling-project.github.io/docling-java"
-        name = project.name
-        description.set(provider { project.description })
-        licenses {
-          license {
-            name = "MIT License"
-            url = "https://opensource.org/license/mit"
+        pom {
+          url = "https://docling-project.github.io/docling-java"
+          name = project.name
+          description.set(provider { project.description })
+          licenses {
+            license {
+              name = "MIT License"
+              url = "https://opensource.org/license/mit"
+            }
           }
-        }
-        properties = project.extra.properties.entries.associate { (k, v) -> k to v.toString() }
-        developers {
-          developer {
-            id = "edeandrea"
-            name = "Eric Deandrea"
-            email = "eric.deandrea@ibm.com"
-            organization = "IBM"
+          properties = project.extra.properties.entries.associate { (k, v) -> k to v.toString() }
+          developers {
+            developer {
+              id = "edeandrea"
+              name = "Eric Deandrea"
+              email = "eric.deandrea@ibm.com"
+              organization = "IBM"
+            }
+            developer {
+              id = "ThomasVitale"
+              name = "Thomas Vitale"
+              url = "https://thomasvitale.com"
+            }
+            developer {
+              id = "lordofthejars"
+              name = "Alex Soto"
+              email = "asotobu@gmail.com"
+              url = "https://www.lordofthejars.com"
+              organization = "IBM"
+            }
           }
-          developer {
-            id = "ThomasVitale"
-            name = "Thomas Vitale"
-            url = "https://thomasvitale.com"
+          scm {
+            connection = "scm:git:git://github.com/docling-project/docling-java.git"
+            developerConnection = "scm:git:ssh://github.com:docling-project/docling-java.git"
+            url = "https://github.com/docling-project/docling-java"
           }
-          developer {
-            id = "lordofthejars"
-            name = "Alex Soto"
-            email = "asotobu@gmail.com"
-            url = "https://www.lordofthejars.com"
-            organization = "IBM"
-          }
-        }
-        scm {
-          connection = "scm:git:git://github.com/docling-project/docling-java.git"
-          developerConnection = "scm:git:ssh://github.com:docling-project/docling-java.git"
-          url = "https://github.com/docling-project/docling-java"
         }
       }
     }

--- a/buildSrc/src/main/kotlin/docling-release.gradle.kts
+++ b/buildSrc/src/main/kotlin/docling-release.gradle.kts
@@ -28,13 +28,14 @@ publishing {
         artifact(cyclonedxTask.flatMap { it.jsonOutput }) {
           classifier = "cyclonedx"
           extension = "json"
+          builtBy(cyclonedxTask)
         }
 
-artifact(cyclonedxTask.flatMap { it.xmlOutput }) {
-  classifier = "cyclonedx"
-  extension = "xml"
-  builtBy(cyclonedxTask)
-}
+        artifact(cyclonedxTask.flatMap { it.xmlOutput }) {
+          classifier = "cyclonedx"
+          extension = "xml"
+          builtBy(cyclonedxTask)
+        }
       }
 
       pom {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ quarkus = "3.37.1"
 quarkus-github-api = "1.330.0"
 quarkus-wiremock = "1.6.3"
 wiremock = "3.13.2"
-cyclonedx = "3.2.4"
+cyclonedx = "3.3.0"
 
 [libraries]
 # assertj


### PR DESCRIPTION
Needed because of CycloneDX/cyclonedx-gradle-plugin#821

- Upgraded CycloneDX Gradle plugin from v3.2.4 to v3.3.0
- Improved artifact publishing by leveraging `flatMap` for task outputs
- Simplified test suite configuration by replacing `val test` with `getByName`