### PR TITLE
test(client): improve coverage of DoclingServeClientException

### DIFF
--- a/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/DoclingServeClientExceptionTests.java
+++ b/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/DoclingServeClientExceptionTests.java
@@ -1,0 +1,57 @@
+package ai.docling.serve.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DoclingServeClientExceptionTests {
+  @Test
+  void constructWithCause() {
+    var cause = new RuntimeException("original");
+    var exception = new DoclingServeClientException(cause);
+
+    assertThat(exception.getMessage()).isEqualTo("original");
+    assertThat(exception.getCause()).isSameAs(cause);
+    assertThat(exception.getStatusCode()).isEqualTo(-1);
+    assertThat(exception.getResponseBody()).isNull();
+  }
+
+  @Test
+  void constructWithNullCause() {
+    var exception = new DoclingServeClientException((Throwable) null);
+
+    assertThat(exception.getMessage()).isEqualTo("An error occurred");
+    assertThat(exception.getCause()).isNull();
+    assertThat(exception.getStatusCode()).isEqualTo(-1);
+    assertThat(exception.getResponseBody()).isNull();
+  }
+
+  @Test
+  void constructWithCauseAndMessage() {
+    var cause = new RuntimeException("root");
+    var exception = new DoclingServeClientException(cause, "custom message");
+
+    assertThat(exception.getMessage()).isEqualTo("custom message");
+    assertThat(exception.getCause()).isSameAs(cause);
+    assertThat(exception.getStatusCode()).isEqualTo(-1);
+    assertThat(exception.getResponseBody()).isNull();
+  }
+
+  @Test
+  void constructWithStatusCodeAndResponseBody() {
+    var exception = new DoclingServeClientException("request failed", 503, "Service Unavailable");
+
+    assertThat(exception.getMessage()).isEqualTo("request failed");
+    assertThat(exception.getStatusCode()).isEqualTo(503);
+    assertThat(exception.getResponseBody()).isEqualTo("Service Unavailable");
+    assertThat(exception.getCause()).isNull();
+  }
+
+  @Test
+  void constructWithStatusCodeAndNullResponseBody() {
+    var exception = new DoclingServeClientException("not found", 404, null);
+
+    assertThat(exception.getStatusCode()).isEqualTo(404);
+    assertThat(exception.getResponseBody()).isNull();
+  }
+}

--- a/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/DoclingServeClientExceptionTests.java
+++ b/docling-serve/docling-serve-client/src/test/java/ai/docling/serve/client/DoclingServeClientExceptionTests.java
@@ -51,6 +51,7 @@ class DoclingServeClientExceptionTests {
   void constructWithStatusCodeAndNullResponseBody() {
     var exception = new DoclingServeClientException("not found", 404, null);
 
+    assertThat(exception.getMessage()).isEqualTo("not found");
     assertThat(exception.getStatusCode()).isEqualTo(404);
     assertThat(exception.getResponseBody()).isNull();
   }


### PR DESCRIPTION
## Summary

Adds full unit test coverage for `DoclingServeClientException`

## Changes

### New Test Class

| File | Class Under Test | # Tests |
|---|---|---|
| `DoclingServeClientExceptionTests` | `DoclingServeClientException` | 5 |

## Coverage Highlights

`DoclingServeClientException` — covers all three constructor variants:

- **`constructWithCause`** — verifies message is taken from the cause, cause is retained, and default status code/response body values are set.
- **`constructWithNullCause`** — verifies fallback message `"An error occurred"` is used when cause is `null`.
- **`constructWithCauseAndMessage`** — verifies an explicit message overrides the cause message.
- **`constructWithStatusCodeAndResponseBody`** — verifies message, status code, response body, and `null` cause.
- **`constructWithStatusCodeAndNullResponseBody`** — verifies message, status code, and `null` response body are all propagated correctly.