### PR TITLE
fix: enable immutableRelease for GitHub releases

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -40,6 +40,7 @@ release:
   github:
     enabled: true
     overwrite: true
+    immutableRelease: true
     name: docling-java
     sign: true
     discussionCategoryName: Announcements


### PR DESCRIPTION
## Summary

- Enables `immutableRelease: true` in `jreleaser.yml` to fix release pipeline failures when the changelog exceeds 10K characters

## Problem

The [v0.6.1 release workflow](https://github.com/docling-project/docling-java/actions/runs/31016776371/job/92342766144#step:11:223) failed with:

```
Cannot upload assets to an immutable release.
```

When the generated changelog exceeds 10K characters, JReleaser trims the release body and uploads the full changelog as a `RELEASE.md` asset. However, because `discussionCategoryName: Announcements` is configured, the release becomes immutable upon publishing (GitHub links a Discussion to it), causing the subsequent asset upload to fail.

## Fix

Setting `immutableRelease: true` changes JReleaser's order of operations: it creates the release as a **draft** first, uploads all assets, and only then publishes — avoiding the immutability conflict.

## Test plan

- [ ] Verify the next release pipeline succeeds end-to-end (Maven Central deploy + GitHub Release with assets + Discussion link + Discord announcement)